### PR TITLE
Fix missing values in grdc data

### DIFF
--- a/ewatercycle/observation/grdc.py
+++ b/ewatercycle/observation/grdc.py
@@ -116,10 +116,7 @@ def _grdc_read(grdc_station_path, start, end):
 
     # Fix missing values
     grdc_station_fix = grdc_station_select.copy()
-    if not grdc_station_fix['streamflow'].dtypes == np.float:
-        raise TypeError("Data has non-float values!")
-    else:
-        grdc_station_fix['streamflow'].replace(-999.0, np.NaN, inplace=True)
+    grdc_station_fix['streamflow'].replace(-999.0, np.NaN, inplace=True)
 
     return metadata, grdc_station_fix
 

--- a/ewatercycle/observation/grdc.py
+++ b/ewatercycle/observation/grdc.py
@@ -102,7 +102,8 @@ def _grdc_read(grdc_station_path, start, end):
         grdc_station_path,
         skiprows=header,
         delimiter=';',
-        parse_dates=['YYYY-MM-DD'])
+        parse_dates=['YYYY-MM-DD'],
+        na_values='-999')
     grdc_station_df = grdc_station_df.rename(columns={
         'YYYY-MM-DD': 'time',
         ' Value': 'streamflow'
@@ -114,11 +115,7 @@ def _grdc_read(grdc_station_path, start, end):
     # Select GRDC station data that matches the forecast results Date
     grdc_station_select = grdc_station_df.loc[start:end]
 
-    # Fix missing values
-    grdc_station_fix = grdc_station_select.copy()
-    grdc_station_fix['streamflow'].replace(-999.0, np.NaN, inplace=True)
-
-    return metadata, grdc_station_fix
+    return metadata, grdc_station_select
 
 
 def _grdc_metadata_reader(grdc_station_path, allLines):

--- a/ewatercycle/observation/grdc.py
+++ b/ewatercycle/observation/grdc.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime
 
 import pandas as pd
+import numpy as np
 
 
 def get_grdc_data(station_id,
@@ -112,6 +113,14 @@ def _grdc_read(grdc_station_path, start, end):
 
     # Select GRDC station data that matches the forecast results Date
     grdc_station_select = grdc_station_df.loc[start:end]
+
+    # Fix missing values
+    if not grdc_station_select['streamflow'].dtypes == np.float:
+        raise TypeError("Data has non-float values!")
+    else:
+        grdc_station_select['streamflow'].replace(
+            -999.0, np.NaN, inplace=True
+            )
 
     return metadata, grdc_station_select
 

--- a/ewatercycle/observation/grdc.py
+++ b/ewatercycle/observation/grdc.py
@@ -115,14 +115,13 @@ def _grdc_read(grdc_station_path, start, end):
     grdc_station_select = grdc_station_df.loc[start:end]
 
     # Fix missing values
-    if not grdc_station_select['streamflow'].dtypes == np.float:
+    grdc_station_fix = grdc_station_select.copy()
+    if not grdc_station_fix['streamflow'].dtypes == np.float:
         raise TypeError("Data has non-float values!")
     else:
-        grdc_station_select['streamflow'].replace(
-            -999.0, np.NaN, inplace=True
-            )
+        grdc_station_fix['streamflow'].replace(-999.0, np.NaN, inplace=True)
 
-    return metadata, grdc_station_select
+    return metadata, grdc_station_fix
 
 
 def _grdc_metadata_reader(grdc_station_path, allLines):

--- a/ewatercycle/observation/grdc.py
+++ b/ewatercycle/observation/grdc.py
@@ -2,7 +2,6 @@ import os
 from datetime import datetime
 
 import pandas as pd
-import numpy as np
 
 
 def get_grdc_data(station_id,

--- a/tests/observation/test_grdc.py
+++ b/tests/observation/test_grdc.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import pytest
 import xarray as xa
+import numpy as np
 from xarray.testing import assert_equal
 
 from ewatercycle.observation.grdc import get_grdc_data
@@ -49,7 +50,7 @@ def sample_grdc_file(tmp_path):
 YYYY-MM-DD;hh:mm; Value
 2000-01-01;--:--;    123.000
 2000-01-02;--:--;    456.000
-2000-01-03;--:--;    789.000'''
+2000-01-03;--:--;    -999.000'''
     with open(fn, 'w') as f:
         f.write(s)
     return fn
@@ -59,7 +60,7 @@ def test_get_grdc_data(tmp_path, sample_grdc_file):
     result = get_grdc_data('42424242', '2000-01-01', '2000-02-01', data_home=tmp_path)
 
     expected = xa.Dataset(
-        {'streamflow': ('time', [123., 456., 789.])},
+        {'streamflow': ('time', [123., 456., np.nan])},
         coords={'time': [datetime(2000, 1, 1), datetime(2000, 1, 2), datetime(2000, 1, 3)]},
         attrs={
             'altitude_masl': 8.0,

--- a/tests/observation/test_grdc.py
+++ b/tests/observation/test_grdc.py
@@ -60,7 +60,7 @@ def test_get_grdc_data(tmp_path, sample_grdc_file):
     result = get_grdc_data('42424242', '2000-01-01', '2000-02-01', data_home=tmp_path)
 
     expected = xa.Dataset(
-        {'streamflow': ('time', [123., 456., np.nan])},
+        {'streamflow': ('time', [123., 456., np.NaN])},
         coords={'time': [datetime(2000, 1, 1), datetime(2000, 1, 2), datetime(2000, 1, 3)]},
         attrs={
             'altitude_masl': 8.0,


### PR DESCRIPTION
This PR replaces -999.0 values with np.nan in grdc streamflow values. Thus, other packages like hydrostats and matplotlib handle missing values correctly. 