### PR TITLE
Remove references to parametersetdb from docs configuration

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
-SPHINXPROJ    = ewatercycle_parametersetdb
+SPHINXPROJ    = ewatercycle
 SOURCEDIR     = .
 BUILDDIR      = _build
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# ewatercycle_parametersetdb documentation build configuration file, created by
+# ewatercycle documentation build configuration file, created by
 # sphinx-quickstart on Wed Aug 29 15:40:09 2018.
 #
 # This file is execfile()d with the current directory set to its
@@ -47,7 +47,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'ewatercycle-parametersetdb'
+project = u'ewatercycle'
 copyright = u'2018, Netherlands eScience Center & Delft University of Technology'
 author = u'Stefan Verhoeven'
 
@@ -148,7 +148,7 @@ html_sidebars = {
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'ewatercycle_parametersetdb_doc'
+htmlhelp_basename = 'ewatercycle_doc'
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -175,7 +175,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'ewatercycle_parametersetdb.tex', u'ewatercycle_parametersetdb Documentation',
+    (master_doc, 'ewatercycle.tex', u'ewatercycle Documentation',
      u'Stefan Verhoeven', 'manual'),
 ]
 
@@ -185,7 +185,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'ewatercycle_parametersetdb', u'ewatercycle_parametersetdb Documentation',
+    (master_doc, 'ewatercycle', u'ewatercycle Documentation',
      [author], 1)
 ]
 
@@ -196,7 +196,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'ewatercycle_parametersetdb', u'ewatercycle_parametersetdb Documentation',
-     author, 'ewatercycle_parametersetdb', 'Python utilities to gather input files for running a hydrology model',
+    (master_doc, 'ewatercycle', u'ewatercycle Documentation',
+     author, 'ewatercycle', 'Python utilities to gather input files for running a hydrology model',
      'Miscellaneous'),
 ]

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -9,7 +9,7 @@ if "%SPHINXBUILD%" == "" (
 )
 set SOURCEDIR=.
 set BUILDDIR=_build
-set SPHINXPROJ=ewatercycle_parametersetdb
+set SPHINXPROJ=ewatercycle
 
 if "%1" == "" goto help
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,8 +2,10 @@
 name: ewatercycle
 channels:
   - conda-forge
+  - esmvalgroup
   - defaults
 dependencies:
+  - esmvaltool-python
   - python>=3.6
   - numpy
   - pandas

--- a/ewatercycle/forcing.py
+++ b/ewatercycle/forcing.py
@@ -1,0 +1,341 @@
+from esmvalcore.experimental import get_recipe
+from pathlib import Path
+
+FORCINGS = {
+    'ERA5': {
+        'dataset': 'ERA5',
+        'project': 'OBS6',
+        'tier': 3,
+        'type': 'reanaly',
+        'version': 1
+    },
+    'ERA-Interim': {
+        'dataset': 'ERA-Interim',
+        'project': 'OBS6',
+        'tier': 3,
+        'type': 'reanaly',
+        'version': 1
+    },
+}
+
+
+def update_hype(
+    data: dict,
+    *,
+    forcings: list = None,
+    startyear: int = None,
+    endyear: int = None,
+    shapefile: str = None,
+):
+    """
+    Update hype recipe data in-place.
+    
+    Parameters
+    ----------
+    forcings : list
+        List of forcings to use
+    startyear : int
+        Start year for the observation data
+    endyear : int
+        End year for the observation data
+    shapefile : str
+        Name of the shapefile to use.
+    """
+    preproc_names = ('preprocessor', 'temperature', 'water')
+
+    if shapefile is not None:
+        for preproc_name in preproc_names:
+            data['preprocessors'][preproc_name]['extract_shape'][
+                'shapefile'] = shapefile
+
+    if forcings is not None:
+        datasets = [FORCINGS[forcing] for forcing in forcings]
+        data['datasets'] = datasets
+
+    variables = data['diagnostics']['hype']['variables']
+    var_names = 'tas', 'tasmin', 'tasmax', 'pr'
+
+    if startyear is not None:
+        for var_name in var_names:
+            variables[var_name]['start_year'] = startyear
+
+    if endyear is not None:
+        for var_name in var_names:
+            variables[var_name]['end_year'] = endyear
+
+    return data
+
+
+def update_lisflood(
+    data: dict,
+    *,
+    forcings: list = None,
+    startyear: int = None,
+    endyear: int = None,
+    shapefile: str = None,
+    extract_region: dict = None,
+):
+    """
+    Update lisflood recipe data in-place.
+
+    Parameters
+    ----------
+    forcings : list
+        List of forcings to use
+    startyear : int
+        Start year for the observation data
+    endyear : int
+        End year for the observation data
+    basin : str
+        Name of the basin to use. Defines the shapefile.
+    extract_region : dict
+        Region specification, must contain `start_longitude`, 
+        `end_longitude`, `start_latitude`, `end_latitude`
+    """
+    preproc_names = ('general', 'daily_water', 'daily_temperature',
+                     'daily_radiation', 'daily_windspeed')
+
+    if shapefile is not None:
+        basin = Path(shapefile).stem
+        for preproc_name in preproc_names:
+            data['preprocessors'][preproc_name]['extract_shape'][
+                'shapefile'] = shapefile
+        data['diagnostics']['diagnostic_daily']['scripts']['script'][
+            'catchment'] = basin
+
+    if extract_region is not None:
+        for preproc_name in preproc_names:
+            data['preprocessors'][preproc_name][
+                'extract_region'] = extract_region
+
+    if forcings is not None:
+        datasets = [FORCINGS[forcing] for forcing in forcings]
+        data['datasets'] = datasets
+
+    variables = data['diagnostics']['diagnostic_daily']['variables']
+    var_names = 'pr', 'tas', 'tasmax', 'tasmin', 'tdps', 'uas', 'vas', 'rsds'
+
+    if startyear is not None:
+        for var_name in var_names:
+            variables[var_name]['start_year'] = startyear
+
+    if endyear is not None:
+        for var_name in var_names:
+            variables[var_name]['end_year'] = endyear
+
+    return data
+
+
+def update_marrmot(
+    data: dict,
+    *,
+    forcings: list = None,
+    startyear: int = None,
+    endyear: int = None,
+    shapefile: str = None,
+):
+    """
+    Update marmott recipe data in-place.
+
+    Parameters
+    ----------
+    forcings : list
+        List of forcings to use
+    startyear : int
+        Start year for the observation data
+    endyear : int
+        End year for the observation data
+    basin : str
+        Name of the basin to use. Defines the shapefile.
+    """
+
+    if shapefile is not None:
+        basin = Path(shapefile).stem
+        data['preprocessors']['daily']['extract_shape'][
+            'shapefile'] = shapefile
+        data['diagnostics']['diagnostic_daily']['scripts']['script'][
+            'basin'] = basin
+
+    if forcings is not None:
+        datasets = [FORCINGS[forcing] for forcing in forcings]
+        data['diagnostics']['diagnostic_daily'][
+            'additional_datasets'] = datasets
+
+    variables = data['diagnostics']['diagnostic_daily']['variables']
+    var_names = 'tas', 'pr', 'psl', 'rsds', 'rsdt'
+
+    if startyear is not None:
+        for var_name in var_names:
+            variables[var_name]['start_year'] = startyear
+
+    if endyear is not None:
+        for var_name in var_names:
+            variables[var_name]['end_year'] = endyear
+
+    return data
+
+
+def update_pcrglobwb(data: dict,
+                     *,
+                     forcings: list = None,
+                     basin: str = None,
+                     startyear: int = None,
+                     endyear: int = None,
+                     startyear_climatology: int = None,
+                     endyear_climatology: int = None,
+                     extract_region: dict = None):
+    """
+    Update pcrglobwb recipe data in-place.
+    
+    Parameters
+    ----------
+    forcings : list
+        List of forcings to use
+    basin : str
+        Name of the basin (used for data output filename only)
+    startyear : int
+        Start year for the observation data
+    endyear : int
+        End year for the observation data
+    startyear_climatology : int
+        Start year for the climatology data
+    endyear_climatology : int
+        End year for the climatology data
+    extract_region : dict
+        Region specification, must contain `start_longitude`, 
+        `end_longitude`, `start_latitude`, `end_latitude`
+    """
+    preproc_names = ('crop_basin', 'preproc_pr', 'preproc_tas',
+                     'preproc_pr_clim', 'preproc_tas_clim')
+
+    if forcings is not None:
+        datasets = [FORCINGS[forcing] for forcing in forcings]
+        data['diagnostics']['diagnostic_daily'][
+            'additional_datasets'] = datasets
+
+    if basin is not None:
+        data['diagnostics']['diagnostic_daily']['scripts']['script'][
+            'basin'] = basin
+
+    if extract_region is not None:
+        for preproc_name in preproc_names:
+            data['preprocessors'][preproc_name][
+                'extract_region'] = extract_region
+
+    variables = data['diagnostics']['diagnostic_daily']['variables']
+    var_names = 'tas', 'pr'
+
+    if startyear is not None:
+        for var_name in var_names:
+            variables[var_name]['start_year'] = startyear
+
+    if endyear is not None:
+        for var_name in var_names:
+            variables[var_name]['end_year'] = endyear
+
+    var_names_climatology = 'pr_climatology', 'tas_climatology'
+
+    if startyear_climatology is not None:
+        for var_name in var_names_climatology:
+            variables[var_name]['start_year'] = startyear_climatology
+
+    if endyear_climatology is not None:
+        for var_name in var_names_climatology:
+            variables[var_name]['end_year'] = endyear_climatology
+
+    return data
+
+
+def update_wflow(
+    data: dict,
+    *,
+    forcings: list = None,
+    startyear: int = None,
+    endyear: int = None,
+    extract_region: dict = None,
+    dem_file: str = None,
+):
+    """
+    Update wflow recipe data in-place.
+
+    Parameters
+    ----------
+    forcings : list
+        List of forcings to use
+    startyear : int
+        Start year for the observation data
+    endyear : int
+        End year for the observation data
+    extract_region : dict
+        Region specification, must contain `start_longitude`, 
+        `end_longitude`, `start_latitude`, `end_latitude`
+    dem_file : str
+        Name of the dem_file to use. Also defines the basin param.
+    """
+    if dem_file is not None:
+        script = data['diagnostics']['wflow_daily']['scripts']['script']
+        script['dem_file'] = dem_file
+        script['basin'] = Path(dem_file).stem
+
+    if extract_region is not None:
+        data['preprocessors']['rough_cutout'][
+            'extract_region'] = extract_region
+
+    if forcings is not None:
+        datasets = [FORCINGS[forcing] for forcing in forcings]
+        data['diagnostics']['wflow_daily']['additional_datasets'] = datasets
+
+    variables = data['diagnostics']['wflow_daily']['variables']
+    var_names = 'tas', 'pr', 'psl', 'rsds', 'rsdt'
+
+    if startyear is not None:
+        for var_name in var_names:
+            variables[var_name]['start_year'] = startyear
+
+    if endyear is not None:
+        for var_name in var_names:
+            variables[var_name]['end_year'] = endyear
+
+    return data
+
+
+MODEL_DATA = {
+    'hype': {
+        'recipe_name': 'hydrology/recipe_hype.yml',
+        'update_func': update_hype,
+    },
+    'lisflood': {
+        'recipe_name': 'hydrology/recipe_lisflood.yml',
+        'update_func': update_lisflood,
+    },
+    'marrmot': {
+        'recipe_name': 'hydrology/recipe_marrmot.yml',
+        'update_func': update_marrmot,
+    },
+    'pcrglobwb': {
+        'recipe_name': 'hydrology/recipe_pcrglobwb.yml',
+        'update_func': update_pcrglobwb,
+    },
+    'wflow': {
+        'recipe_name': 'hydrology/recipe_wflow.yml',
+        'update_func': update_wflow,
+    },
+}
+
+
+def generate(model: str, **kwargs):
+    """
+    Parameters
+    ----------
+    model : str
+        Name of the model
+    **kwargs :
+        Model specific parameters
+    """
+    model_data = MODEL_DATA[model]
+    recipe_name = model_data['recipe_name']
+    recipe = get_recipe(recipe_name)
+
+    update_func = model_data['update_func']
+    update_func(recipe.data, **kwargs)
+    recipe.run()

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,12 @@ source = ewatercycle
 
 [tool:pytest]
 testpaths = tests
-addopts = --cov --cov-report xml --cov-report term --cov-report html --junit-xml=xunit-result.xml
+addopts =
+    --cov
+    --cov-report xml
+    --cov-report term
+    --cov-report html
+    --junit-xml=xunit-result.xml
 
 # Define `python setup.py build_sphinx`
 [build_sphinx]

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'sphinx_rtd_theme',
     ],
     tests_require=[
+        'deepdiff',
         'pytest',
         'pytest-cov',
         'pycodestyle',

--- a/tests/test_forcing.py
+++ b/tests/test_forcing.py
@@ -2,7 +2,7 @@ from esmvalcore.experimental import get_recipe
 import deepdiff
 import copy
 import pytest
-from forcing import update_marrmot, update_lisflood, update_hype, update_wflow, update_pcrglobwb
+from ewatercycle.forcing import update_marrmot, update_lisflood, update_hype, update_wflow, update_pcrglobwb
 
 TEST_INPUT_MARRMOT = (
     {},

--- a/tests/test_forcing.py
+++ b/tests/test_forcing.py
@@ -1,0 +1,1025 @@
+from esmvalcore.experimental import get_recipe
+import deepdiff
+import copy
+import pytest
+from forcing import update_marrmot, update_lisflood, update_hype, update_wflow, update_pcrglobwb
+
+TEST_INPUT_MARRMOT = (
+    {},
+    {
+        'startyear': 1990,
+        'endyear': 2018,
+        'forcings': ['ERA-Interim', 'ERA5'],
+        'shapefile': 'Meuse/Meuse.shp',
+    },
+    {
+        'startyear': 1234
+    },
+    {
+        'endyear': 4321
+    },
+    {
+        'forcings': ['ERA5']
+    },
+    {
+        'shapefile': 'Rhine/Rhine.shp'
+    },
+)
+
+TEST_INPUT_LISFLOOD = (
+    {},
+    {
+        'startyear': 1990,
+        'endyear': 1990,
+        'forcings': ['ERA-Interim', 'ERA5'],
+        'shapefile': 'Lorentz_Basin_Shapefiles/Meuse/Meuse.shp',
+        'extract_region': {
+            'start_longitude': 0,
+            'end_longitude': 9,
+            'start_latitude': 45,
+            'end_latitude': 54,
+        },
+    },
+    {
+        'startyear': 1234
+    },
+    {
+        'endyear': 4321
+    },
+    {
+        'forcings': ['ERA5']
+    },
+    {
+        'shapefile': 'Rhine/Rhine.shp'
+    },
+    {
+        'extract_region': {
+            'start_longitude': 12,
+            'end_longitude': 34,
+            'start_latitude': 56,
+            'end_latitude': 78,
+        }
+    },
+)
+
+TEST_INPUT_HYPE = (
+    {},
+    {
+        'startyear': 1979,
+        'endyear': 1979,
+        'forcings': ['ERA-Interim', 'ERA5'],
+        'shapefile': 'Meuse_HYPE.shp',
+    },
+    {
+        'startyear': 1234
+    },
+    {
+        'endyear': 4321
+    },
+    {
+        'forcings': ['ERA5']
+    },
+    {
+        'shapefile': 'Rhine_HYPE.shp'
+    },
+)
+
+TEST_INPUT_WFLOW = (
+    {},
+    {
+        'startyear': 1990,
+        'endyear': 1990,
+        'forcings': ['ERA-Interim', 'ERA5'],
+        'dem_file': 'wflow/wflow_dem_Meuse.nc',
+        'extract_region': {
+            'start_longitude': 0,
+            'end_longitude': 6.75,
+            'start_latitude': 47.25,
+            'end_latitude': 52.5,
+        },
+    },
+    {
+        'startyear': 1234
+    },
+    {
+        'endyear': 4321
+    },
+    {
+        'forcings': ['ERA5']
+    },
+    {
+        'dem_file': 'wflow/wflow_dem_Rhine.nc'
+    },
+    {
+        'extract_region': {
+            'start_longitude': 12,
+            'end_longitude': 34,
+            'start_latitude': 56,
+            'end_latitude': 78,
+        }
+    },
+)
+
+TEST_INPUT_PCRGLOBWB = (
+    {},
+    {
+        'startyear': 2002,
+        'endyear': 2016,
+        'startyear_climatology': 1990,
+        'endyear_climatology': 2002,
+        'forcings': ['ERA-Interim', 'ERA5'],
+        'basin': 'rhine',
+        'extract_region': {
+            'start_longitude': 3,
+            'end_longitude': 13.5,
+            'start_latitude': 45,
+            'end_latitude': 54,
+        },
+    },
+    {
+        'startyear': 1234
+    },
+    {
+        'endyear': 4321
+    },
+    {
+        'startyear_climatology': 1234
+    },
+    {
+        'endyear_climatology': 4321
+    },
+    {
+        'forcings': ['ERA5']
+    },
+    {
+        'basin': 'meuse'
+    },
+    {
+        'extract_region': {
+            'start_longitude': 12,
+            'end_longitude': 34,
+            'start_latitude': 56,
+            'end_latitude': 78,
+        }
+    },
+)
+
+EXPECTED_DIFF_MARRMOT = (
+    {},
+    {},
+    {
+        'values_changed': {
+            "root['diagnostics']['diagnostic_daily']['variables']['tas']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1990
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['pr']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1990
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['psl']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1990
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['rsds']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1990
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['rsdt']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1990
+            }
+        }
+    },
+    {
+        'values_changed': {
+            "root['diagnostics']['diagnostic_daily']['variables']['tas']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 2018
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['pr']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 2018
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['psl']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 2018
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['rsds']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 2018
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['rsdt']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 2018
+            }
+        }
+    },
+    {
+        'values_changed': {
+            "root['diagnostics']['diagnostic_daily']['additional_datasets'][0]['dataset']":
+            {
+                'new_value': 'ERA5',
+                'old_value': 'ERA-Interim'
+            }
+        },
+        'iterable_item_removed': {
+            "root['diagnostics']['diagnostic_daily']['additional_datasets'][1]":
+            {
+                'dataset': 'ERA5',
+                'project': 'OBS6',
+                'tier': 3,
+                'type': 'reanaly',
+                'version': 1
+            }
+        }
+    },
+    {
+        'values_changed': {
+            "root['preprocessors']['daily']['extract_shape']['shapefile']": {
+                'new_value': 'Rhine/Rhine.shp',
+                'old_value': 'Meuse/Meuse.shp'
+            },
+            "root['diagnostics']['diagnostic_daily']['scripts']['script']['basin']":
+            {
+                'new_value': 'Rhine',
+                'old_value': 'Meuse'
+            }
+        }
+    },
+)
+
+EXPECTED_DIFF_LISFLOOD = (
+    {},
+    {},
+    {
+        'values_changed': {
+            "root['diagnostics']['diagnostic_daily']['variables']['pr']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1990
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['tas']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1990
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['tasmax']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1990
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['tasmin']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1990
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['tdps']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1990
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['uas']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1990
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['vas']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1990
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['rsds']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1990
+            }
+        }
+    },
+    {
+        'values_changed': {
+            "root['diagnostics']['diagnostic_daily']['variables']['pr']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 1990
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['tas']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 1990
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['tasmax']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 1990
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['tasmin']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 1990
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['tdps']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 1990
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['uas']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 1990
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['vas']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 1990
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['rsds']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 1990
+            }
+        }
+    },
+    {
+        'values_changed': {
+            "root['datasets'][0]['dataset']": {
+                'new_value': 'ERA5',
+                'old_value': 'ERA-Interim'
+            }
+        },
+        'iterable_item_removed': {
+            "root['datasets'][1]": {
+                'dataset': 'ERA5',
+                'project': 'OBS6',
+                'tier': 3,
+                'type': 'reanaly',
+                'version': 1
+            }
+        }
+    },
+    {
+        'values_changed': {
+            "root['preprocessors']['general']['extract_shape']['shapefile']": {
+                'new_value': 'Rhine/Rhine.shp',
+                'old_value': 'Lorentz_Basin_Shapefiles/Meuse/Meuse.shp'
+            },
+            "root['preprocessors']['daily_water']['extract_shape']['shapefile']":
+            {
+                'new_value': 'Rhine/Rhine.shp',
+                'old_value': 'Lorentz_Basin_Shapefiles/Meuse/Meuse.shp'
+            },
+            "root['preprocessors']['daily_temperature']['extract_shape']['shapefile']":
+            {
+                'new_value': 'Rhine/Rhine.shp',
+                'old_value': 'Lorentz_Basin_Shapefiles/Meuse/Meuse.shp'
+            },
+            "root['preprocessors']['daily_radiation']['extract_shape']['shapefile']":
+            {
+                'new_value': 'Rhine/Rhine.shp',
+                'old_value': 'Lorentz_Basin_Shapefiles/Meuse/Meuse.shp'
+            },
+            "root['preprocessors']['daily_windspeed']['extract_shape']['shapefile']":
+            {
+                'new_value': 'Rhine/Rhine.shp',
+                'old_value': 'Lorentz_Basin_Shapefiles/Meuse/Meuse.shp'
+            },
+            "root['diagnostics']['diagnostic_daily']['scripts']['script']['catchment']":
+            {
+                'new_value': 'Rhine',
+                'old_value': 'Meuse'
+            }
+        }
+    },
+    {
+        'values_changed': {
+            "root['preprocessors']['general']['extract_region']['start_longitude']":
+            {
+                'new_value': 12,
+                'old_value': 0
+            },
+            "root['preprocessors']['general']['extract_region']['end_longitude']":
+            {
+                'new_value': 34,
+                'old_value': 9
+            },
+            "root['preprocessors']['general']['extract_region']['start_latitude']":
+            {
+                'new_value': 56,
+                'old_value': 45
+            },
+            "root['preprocessors']['general']['extract_region']['end_latitude']":
+            {
+                'new_value': 78,
+                'old_value': 54
+            },
+            "root['preprocessors']['daily_water']['extract_region']['start_longitude']":
+            {
+                'new_value': 12,
+                'old_value': 0
+            },
+            "root['preprocessors']['daily_water']['extract_region']['end_longitude']":
+            {
+                'new_value': 34,
+                'old_value': 9
+            },
+            "root['preprocessors']['daily_water']['extract_region']['start_latitude']":
+            {
+                'new_value': 56,
+                'old_value': 45
+            },
+            "root['preprocessors']['daily_water']['extract_region']['end_latitude']":
+            {
+                'new_value': 78,
+                'old_value': 54
+            },
+            "root['preprocessors']['daily_temperature']['extract_region']['start_longitude']":
+            {
+                'new_value': 12,
+                'old_value': 0
+            },
+            "root['preprocessors']['daily_temperature']['extract_region']['end_longitude']":
+            {
+                'new_value': 34,
+                'old_value': 9
+            },
+            "root['preprocessors']['daily_temperature']['extract_region']['start_latitude']":
+            {
+                'new_value': 56,
+                'old_value': 45
+            },
+            "root['preprocessors']['daily_temperature']['extract_region']['end_latitude']":
+            {
+                'new_value': 78,
+                'old_value': 54
+            },
+            "root['preprocessors']['daily_radiation']['extract_region']['start_longitude']":
+            {
+                'new_value': 12,
+                'old_value': 0
+            },
+            "root['preprocessors']['daily_radiation']['extract_region']['end_longitude']":
+            {
+                'new_value': 34,
+                'old_value': 9
+            },
+            "root['preprocessors']['daily_radiation']['extract_region']['start_latitude']":
+            {
+                'new_value': 56,
+                'old_value': 45
+            },
+            "root['preprocessors']['daily_radiation']['extract_region']['end_latitude']":
+            {
+                'new_value': 78,
+                'old_value': 54
+            },
+            "root['preprocessors']['daily_windspeed']['extract_region']['start_longitude']":
+            {
+                'new_value': 12,
+                'old_value': 0
+            },
+            "root['preprocessors']['daily_windspeed']['extract_region']['end_longitude']":
+            {
+                'new_value': 34,
+                'old_value': 9
+            },
+            "root['preprocessors']['daily_windspeed']['extract_region']['start_latitude']":
+            {
+                'new_value': 56,
+                'old_value': 45
+            },
+            "root['preprocessors']['daily_windspeed']['extract_region']['end_latitude']":
+            {
+                'new_value': 78,
+                'old_value': 54
+            }
+        }
+    },
+)
+
+EXPECTED_DIFF_HYPE = (
+    {},
+    {},
+    {
+        'values_changed': {
+            "root['diagnostics']['hype']['variables']['tas']['start_year']": {
+                'new_value': 1234,
+                'old_value': 1979
+            },
+            "root['diagnostics']['hype']['variables']['tasmin']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1979
+            },
+            "root['diagnostics']['hype']['variables']['tasmax']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1979
+            },
+            "root['diagnostics']['hype']['variables']['pr']['start_year']": {
+                'new_value': 1234,
+                'old_value': 1979
+            }
+        }
+    },
+    {
+        'values_changed': {
+            "root['diagnostics']['hype']['variables']['tas']['end_year']": {
+                'new_value': 4321,
+                'old_value': 1979
+            },
+            "root['diagnostics']['hype']['variables']['tasmin']['end_year']": {
+                'new_value': 4321,
+                'old_value': 1979
+            },
+            "root['diagnostics']['hype']['variables']['tasmax']['end_year']": {
+                'new_value': 4321,
+                'old_value': 1979
+            },
+            "root['diagnostics']['hype']['variables']['pr']['end_year']": {
+                'new_value': 4321,
+                'old_value': 1979
+            }
+        }
+    },
+    {
+        'values_changed': {
+            "root['datasets'][0]['dataset']": {
+                'new_value': 'ERA5',
+                'old_value': 'ERA-Interim'
+            }
+        },
+        'iterable_item_removed': {
+            "root['datasets'][1]": {
+                'dataset': 'ERA5',
+                'project': 'OBS6',
+                'tier': 3,
+                'type': 'reanaly',
+                'version': 1
+            }
+        }
+    },
+    {
+        'values_changed': {
+            "root['preprocessors']['preprocessor']['extract_shape']['shapefile']":
+            {
+                'new_value': 'Rhine_HYPE.shp',
+                'old_value': 'Meuse_HYPE.shp'
+            },
+            "root['preprocessors']['temperature']['extract_shape']['shapefile']":
+            {
+                'new_value': 'Rhine_HYPE.shp',
+                'old_value': 'Meuse_HYPE.shp'
+            },
+            "root['preprocessors']['water']['extract_shape']['shapefile']": {
+                'new_value': 'Rhine_HYPE.shp',
+                'old_value': 'Meuse_HYPE.shp'
+            }
+        }
+    },
+)
+
+EXPECTED_DIFF_WFLOW = (
+    {},
+    {
+        'values_changed': {
+            "root['diagnostics']['wflow_daily']['scripts']['script']['basin']":
+            {
+                'new_value': 'wflow_dem_Meuse',
+                'old_value': 'Meuse'
+            }
+        }
+    },
+    {
+        'values_changed': {
+            "root['diagnostics']['wflow_daily']['variables']['tas']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1990
+            },
+            "root['diagnostics']['wflow_daily']['variables']['pr']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1990
+            },
+            "root['diagnostics']['wflow_daily']['variables']['psl']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1990
+            },
+            "root['diagnostics']['wflow_daily']['variables']['rsds']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1990
+            },
+            "root['diagnostics']['wflow_daily']['variables']['rsdt']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1990
+            }
+        }
+    },
+    {
+        'values_changed': {
+            "root['diagnostics']['wflow_daily']['variables']['tas']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 1990
+            },
+            "root['diagnostics']['wflow_daily']['variables']['pr']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 1990
+            },
+            "root['diagnostics']['wflow_daily']['variables']['psl']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 1990
+            },
+            "root['diagnostics']['wflow_daily']['variables']['rsds']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 1990
+            },
+            "root['diagnostics']['wflow_daily']['variables']['rsdt']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 1990
+            }
+        }
+    },
+    {
+        'values_changed': {
+            "root['diagnostics']['wflow_daily']['additional_datasets'][0]['dataset']":
+            {
+                'new_value': 'ERA5',
+                'old_value': 'ERA-Interim'
+            }
+        },
+        'iterable_item_removed': {
+            "root['diagnostics']['wflow_daily']['additional_datasets'][1]": {
+                'dataset': 'ERA5',
+                'project': 'OBS6',
+                'tier': 3,
+                'type': 'reanaly',
+                'version': 1
+            }
+        }
+    },
+    {
+        'values_changed': {
+            "root['diagnostics']['wflow_daily']['scripts']['script']['basin']":
+            {
+                'new_value': 'wflow_dem_Rhine',
+                'old_value': 'Meuse'
+            },
+            "root['diagnostics']['wflow_daily']['scripts']['script']['dem_file']":
+            {
+                'new_value': 'wflow/wflow_dem_Rhine.nc',
+                'old_value': 'wflow/wflow_dem_Meuse.nc'
+            }
+        }
+    },
+    {
+        'type_changes': {
+            "root['preprocessors']['rough_cutout']['extract_region']['end_longitude']":
+            {
+                'old_type': float,
+                'new_type': int,
+                'old_value': 6.75,
+                'new_value': 34
+            },
+            "root['preprocessors']['rough_cutout']['extract_region']['start_latitude']":
+            {
+                'old_type': float,
+                'new_type': int,
+                'old_value': 47.25,
+                'new_value': 56
+            },
+            "root['preprocessors']['rough_cutout']['extract_region']['end_latitude']":
+            {
+                'old_type': float,
+                'new_type': int,
+                'old_value': 52.5,
+                'new_value': 78
+            }
+        },
+        'values_changed': {
+            "root['preprocessors']['rough_cutout']['extract_region']['start_longitude']":
+            {
+                'new_value': 12,
+                'old_value': 0
+            }
+        }
+    },
+)
+
+EXPECTED_DIFF_PCRGLOBWB = (
+    {},
+    {},
+    {
+        'values_changed': {
+            "root['diagnostics']['diagnostic_daily']['variables']['pr']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 2002
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['tas']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 2002
+            }
+        }
+    },
+    {
+        'values_changed': {
+            "root['diagnostics']['diagnostic_daily']['variables']['pr']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 2016
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['tas']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 2016
+            }
+        }
+    },
+    {
+        'values_changed': {
+            "root['diagnostics']['diagnostic_daily']['variables']['pr_climatology']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1990
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['tas_climatology']['start_year']":
+            {
+                'new_value': 1234,
+                'old_value': 1990
+            }
+        }
+    },
+    {
+        'values_changed': {
+            "root['diagnostics']['diagnostic_daily']['variables']['pr_climatology']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 2002
+            },
+            "root['diagnostics']['diagnostic_daily']['variables']['tas_climatology']['end_year']":
+            {
+                'new_value': 4321,
+                'old_value': 2002
+            }
+        }
+    },
+    {
+        'values_changed': {
+            "root['diagnostics']['diagnostic_daily']['additional_datasets'][0]['dataset']":
+            {
+                'new_value': 'ERA5',
+                'old_value': 'ERA-Interim'
+            }
+        },
+        'iterable_item_removed': {
+            "root['diagnostics']['diagnostic_daily']['additional_datasets'][1]":
+            {
+                'dataset': 'ERA5',
+                'project': 'OBS6',
+                'tier': 3,
+                'type': 'reanaly',
+                'version': 1
+            }
+        }
+    },
+    {
+        'values_changed': {
+            "root['diagnostics']['diagnostic_daily']['scripts']['script']['basin']":
+            {
+                'new_value': 'meuse',
+                'old_value': 'rhine'
+            }
+        }
+    },
+    {
+        'type_changes': {
+            "root['preprocessors']['crop_basin']['extract_region']['end_longitude']":
+            {
+                'old_type': float,
+                'new_type': int,
+                'old_value': 13.5,
+                'new_value': 34
+            },
+            "root['preprocessors']['preproc_pr']['extract_region']['end_longitude']":
+            {
+                'old_type': float,
+                'new_type': int,
+                'old_value': 13.5,
+                'new_value': 34
+            },
+            "root['preprocessors']['preproc_tas']['extract_region']['end_longitude']":
+            {
+                'old_type': float,
+                'new_type': int,
+                'old_value': 13.5,
+                'new_value': 34
+            },
+            "root['preprocessors']['preproc_pr_clim']['extract_region']['end_longitude']":
+            {
+                'old_type': float,
+                'new_type': int,
+                'old_value': 13.5,
+                'new_value': 34
+            },
+            "root['preprocessors']['preproc_tas_clim']['extract_region']['end_longitude']":
+            {
+                'old_type': float,
+                'new_type': int,
+                'old_value': 13.5,
+                'new_value': 34
+            }
+        },
+        'values_changed': {
+            "root['preprocessors']['crop_basin']['extract_region']['start_longitude']":
+            {
+                'new_value': 12,
+                'old_value': 3
+            },
+            "root['preprocessors']['crop_basin']['extract_region']['start_latitude']":
+            {
+                'new_value': 56,
+                'old_value': 45
+            },
+            "root['preprocessors']['crop_basin']['extract_region']['end_latitude']":
+            {
+                'new_value': 78,
+                'old_value': 54
+            },
+            "root['preprocessors']['preproc_pr']['extract_region']['start_longitude']":
+            {
+                'new_value': 12,
+                'old_value': 3
+            },
+            "root['preprocessors']['preproc_pr']['extract_region']['start_latitude']":
+            {
+                'new_value': 56,
+                'old_value': 45
+            },
+            "root['preprocessors']['preproc_pr']['extract_region']['end_latitude']":
+            {
+                'new_value': 78,
+                'old_value': 54
+            },
+            "root['preprocessors']['preproc_tas']['extract_region']['start_longitude']":
+            {
+                'new_value': 12,
+                'old_value': 3
+            },
+            "root['preprocessors']['preproc_tas']['extract_region']['start_latitude']":
+            {
+                'new_value': 56,
+                'old_value': 45
+            },
+            "root['preprocessors']['preproc_tas']['extract_region']['end_latitude']":
+            {
+                'new_value': 78,
+                'old_value': 54
+            },
+            "root['preprocessors']['preproc_pr_clim']['extract_region']['start_longitude']":
+            {
+                'new_value': 12,
+                'old_value': 3
+            },
+            "root['preprocessors']['preproc_pr_clim']['extract_region']['start_latitude']":
+            {
+                'new_value': 56,
+                'old_value': 45
+            },
+            "root['preprocessors']['preproc_pr_clim']['extract_region']['end_latitude']":
+            {
+                'new_value': 78,
+                'old_value': 54
+            },
+            "root['preprocessors']['preproc_tas_clim']['extract_region']['start_longitude']":
+            {
+                'new_value': 12,
+                'old_value': 3
+            },
+            "root['preprocessors']['preproc_tas_clim']['extract_region']['start_latitude']":
+            {
+                'new_value': 56,
+                'old_value': 45
+            },
+            "root['preprocessors']['preproc_tas_clim']['extract_region']['end_latitude']":
+            {
+                'new_value': 78,
+                'old_value': 54
+            }
+        }
+    },
+)
+
+TEST_CASES_MARRMOT = list(zip(TEST_INPUT_MARRMOT, EXPECTED_DIFF_MARRMOT))
+TEST_CASES_LISFLOOD = list(zip(TEST_INPUT_LISFLOOD, EXPECTED_DIFF_LISFLOOD))
+TEST_CASES_HYPE = list(zip(TEST_INPUT_HYPE, EXPECTED_DIFF_HYPE))
+TEST_CASES_WFLOW = list(zip(TEST_INPUT_WFLOW, EXPECTED_DIFF_WFLOW))
+TEST_CASES_PCRGLOBWB = list(zip(TEST_INPUT_PCRGLOBWB, EXPECTED_DIFF_PCRGLOBWB))
+
+
+def _test_forcing(recipe, update_func, params, expected_diff):
+    expected_data = recipe.data
+    data = copy.deepcopy(expected_data)
+    update_func(data, **params)
+    diff = deepdiff.DeepDiff(recipe.data, data)
+
+    if not diff == expected_diff:
+        raise AssertionError(
+            f'Expected: {expected_diff}\nActual: {diff.pretty()}')
+
+
+@pytest.mark.parametrize('params, expected_diff', TEST_CASES_MARRMOT)
+def test_forcing_marrmot(params, expected_diff):
+    recipe = get_recipe('hydrology/recipe_marrmot.yml')
+    update_func = update_marrmot
+
+    _test_forcing(recipe, update_func, params, expected_diff)
+
+
+@pytest.mark.parametrize('params, expected_diff', TEST_CASES_LISFLOOD)
+def test_forcing_lisflood(params, expected_diff):
+    recipe = get_recipe('hydrology/recipe_lisflood.yml')
+    update_func = update_lisflood
+
+    _test_forcing(recipe, update_func, params, expected_diff)
+
+
+@pytest.mark.parametrize('params, expected_diff', TEST_CASES_HYPE)
+def test_forcing_hype(params, expected_diff):
+    recipe = get_recipe('hydrology/recipe_hype.yml')
+    update_func = update_hype
+
+    _test_forcing(recipe, update_func, params, expected_diff)
+
+
+@pytest.mark.parametrize('params, expected_diff', TEST_CASES_WFLOW)
+def test_forcing_wflow(params, expected_diff):
+    recipe = get_recipe('hydrology/recipe_wflow.yml')
+    update_func = update_wflow
+
+    _test_forcing(recipe, update_func, params, expected_diff)
+
+
+@pytest.mark.parametrize('params, expected_diff', TEST_CASES_PCRGLOBWB)
+def test_forcing_pcrglobwb(params, expected_diff):
+    recipe = get_recipe('hydrology/recipe_pcrglobwb.yml')
+    update_func = update_pcrglobwb
+
+    _test_forcing(recipe, update_func, params, expected_diff)
+
+
+if __name__ == '__main__':
+    model = 'wflow'
+
+    func_list = {
+        'marrmot': update_marrmot,
+        'lisflood': update_lisflood,
+        'hype': update_hype,
+        'wflow': update_wflow,
+        'pcrglobwb': update_pcrglobwb,
+    }
+
+    test_input_list = {
+        'marrmot': TEST_INPUT_MARRMOT,
+        'lisflood': TEST_INPUT_LISFLOOD,
+        'hype': TEST_INPUT_HYPE,
+        'wflow': TEST_INPUT_WFLOW,
+        'pcrglobwb': TEST_INPUT_PCRGLOBWB,
+    }
+
+    recipe = get_recipe(f'hydrology/recipe_{model}.yml')
+    update_func = func_list[model]
+    params_list = test_input_list[model]
+
+    NEW_TEST_CASES = []
+
+    for params in params_list:
+        # generate differences
+        expected_data = recipe.data
+        data = copy.deepcopy(expected_data)
+        update_func(data, **params)
+        diff = deepdiff.DeepDiff(recipe.data, data)
+
+        NEW_TEST_CASES.append(diff)
+
+    NEW_TEST_CASES = tuple(NEW_TEST_CASES)
+
+    breakpoint()


### PR DESCRIPTION
This PR changes the references from ewatercycle_parametersetdb to plain ewatercycle.

So far I only modified the config and makefiles, not the actual references in e.g. index.rst. I think Sarah was working on this file in a separate PR. There are many more references throughout the repo, e.g. also in sonarcloud config.