### PR TITLE
Remove parametersetdb reference from docs config and makefiles

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
-SPHINXPROJ    = ewatercycle_parametersetdb
+SPHINXPROJ    = ewatercycle
 SOURCEDIR     = .
 BUILDDIR      = _build
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# ewatercycle_parametersetdb documentation build configuration file, created by
+# ewatercycle documentation build configuration file, created by
 # sphinx-quickstart on Wed Aug 29 15:40:09 2018.
 #
 # This file is execfile()d with the current directory set to its
@@ -47,7 +47,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'ewatercycle-parametersetdb'
+project = u'ewatercycle'
 copyright = u'2018, Netherlands eScience Center & Delft University of Technology'
 author = u'Stefan Verhoeven'
 
@@ -148,7 +148,7 @@ html_sidebars = {
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'ewatercycle_parametersetdb_doc'
+htmlhelp_basename = 'ewatercycle_doc'
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -175,7 +175,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'ewatercycle_parametersetdb.tex', u'ewatercycle_parametersetdb Documentation',
+    (master_doc, 'ewatercycle.tex', u'ewatercycle Documentation',
      u'Stefan Verhoeven', 'manual'),
 ]
 
@@ -185,7 +185,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'ewatercycle_parametersetdb', u'ewatercycle_parametersetdb Documentation',
+    (master_doc, 'ewatercycle', u'ewatercycle Documentation',
      [author], 1)
 ]
 
@@ -196,7 +196,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'ewatercycle_parametersetdb', u'ewatercycle_parametersetdb Documentation',
-     author, 'ewatercycle_parametersetdb', 'Python utilities to gather input files for running a hydrology model',
+    (master_doc, 'ewatercycle', u'ewatercycle Documentation',
+     author, 'ewatercycle', 'Python utilities to gather input files for running a hydrology model',
      'Miscellaneous'),
 ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,9 @@
-.. ewatercycle_parametersetdb documentation master file, created by
+.. ewatercycle documentation master file, created by
    sphinx-quickstart on Thu Jun 21 11:07:11 2018.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to ewatercycle-parametersetdb's documentation!
+Welcome to ewatercycle's documentation!
 ==========================================================
 
 .. toctree::

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -9,7 +9,7 @@ if "%SPHINXBUILD%" == "" (
 )
 set SOURCEDIR=.
 set BUILDDIR=_build
-set SPHINXPROJ=ewatercycle_parametersetdb
+set SPHINXPROJ=ewatercycle
 
 if "%1" == "" goto help
 


### PR DESCRIPTION
This PR changes the references from ewatercycle_parametersetdb to plain ewatercycle.

So far I only modified the config and makefiles, not the actual references in e.g. index.rst. I think Sarah was working on this file in a separate PR. There are many more references throughout the repo, e.g. also in sonarcloud config.