### PR TITLE
Fix RTD build and badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,8 @@ A Python package for running hydrological models.
 .. image:: https://sonarcloud.io/api/project_badges/measure?project=eWaterCycle_ewatercycle&metric=coverage
     :target: https://sonarcloud.io/component_measures?id=eWaterCycle_ewatercycle&metric=coverage
 
-.. image:: https://readthedocs.org/projects/ewatercycle-parametersetdb/badge/?version=latest
-    :target: https://ewatercycle-parametersetdb.readthedocs.io/en/latest/?badge=latest
+.. image:: https://readthedocs.org/projects/ewatercycle/badge/?version=latest
+    :target: https://ewatercycle.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
 Install

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ ewatercycle
 
 A Python package for running hydrological models.
 
-.. image:: https://github.com/eWaterCycle/parametersetdb/actions/workflows/ci.yml/badge.svg
-    :target: https://github.com/eWaterCycle/parametersetdb/actions/workflows/ci.yml
+.. image:: https://github.com/eWaterCycle/ewatercycle/actions/workflows/ci.yml/badge.svg
+    :target: https://github.com/eWaterCycle/ewatercycle/actions/workflows/ci.yml
 
 .. image:: https://sonarcloud.io/api/project_badges/measure?project=eWaterCycle_ewatercycle&metric=alert_status
     :target: https://sonarcloud.io/dashboard?id=eWaterCycle_ewatercycle

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -209,4 +209,5 @@ autodoc_mock_imports = [
     'scipy',
     'pandas',
     'ruamel',
+    'pyoos',
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -200,3 +200,9 @@ texinfo_documents = [
      author, 'ewatercycle', 'Python utilities to gather input files for running a hydrology model',
      'Miscellaneous'),
 ]
+
+autodoc_mock_imports = [
+    'esmvalcore',
+    'dask',
+    'xarray',
+]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -205,4 +205,8 @@ autodoc_mock_imports = [
     'esmvalcore',
     'dask',
     'xarray',
+    'numpy',
+    'scipy',
+    'pandas',
+    'ruamel',
 ]

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,4 +1,0 @@
-python:
-    version: 3.5
-    pip_install: true
-


### PR DESCRIPTION
This PR fixes a few things that broke since we moved the documentation to a new RTD page (ewatercycle.readthedocs.io). 

- Badge for RTD now refers to the correct page
- Package build badge refers to the correct package
- Broken RTD build is fixed (by mocking dependencies instead of installing them)

closes #30 