### PR TITLE
Add get_value_as_xarray method to model API

### DIFF
--- a/ewatercycle/models/abstract.py
+++ b/ewatercycle/models/abstract.py
@@ -1,8 +1,9 @@
-from abc import abstractmethod, ABCMeta
+from abc import ABCMeta, abstractmethod
 from os import PathLike
-from typing import Tuple, Iterable, Any, Optional
+from typing import Any, Iterable, Optional, Tuple
 
 import numpy as np
+import xarray as xr
 from basic_modeling_interface import Bmi
 
 
@@ -68,6 +69,17 @@ class AbstractModel:
 
         """
         self.bmi.set_value(name, value)
+
+    @abstractmethod
+    def get_value_as_xarray(self, name: str) -> xr.DataArray:
+        """Get a copy values of the given variable as xarray DataArray.
+
+        The xarray object also contains coordinate information and additional
+        attributes such as the units.
+
+        Args: name: Name of the variable
+
+        """
 
     @property
     @abstractmethod

--- a/tests/models/test_abstract.py
+++ b/tests/models/test_abstract.py
@@ -137,11 +137,13 @@ def test_output_var_names(bmi, model: MockedModel):
 
 
 def test_get_value_as_xarray(model: MockedModel):
-    expected = np.array([[1.0, 2.0]])
+    expected = xr.DataArray(
+            data=[[1.0, 2.0]],
+            dims=["time", "x"],
+            name='Temperature',
+            attrs=dict(units="degC"),
+        )
 
     dataarray = model.get_value_as_xarray("Temperature")
 
-    assert_array_equal(dataarray.values, expected)
-    assert dataarray.name == "Temperature"
-    assert dataarray.units == "degC"
-    assert isinstance(dataarray, xr.DataArray)
+    xr.testing.assert_equal(dataarray, expected)


### PR DESCRIPTION
This PR adds a method to the model API to get the values of a variable as `xarray.DataArray`

(also sorted the imports)