### PR TITLE
Bundle model-specific docstrings and hide their classes from public api

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,8 @@
+version: 2
+conda:
+  environment: environment.yml
+python:
+  install:
+    - method: pip
+      path: .
+

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,0 @@
-version: 2
-conda:
-  environment: environment.yml
-python:
-  install:
-    - method: pip
-      path: .
-

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -207,6 +207,7 @@ autodoc_mock_imports = [
     'dask',
     'esmvalcore',
     'fiona',
+    'dateutil',
     'hydrostats',
     'matplotlib',
     'numpy',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -219,3 +219,12 @@ autodoc_mock_imports = [
 
 # Prevent alphabetic sorting of (@data)class attributes/methods
 autodoc_member_order = 'bysource'
+
+# Nice formatting of model-specific input parameters
+napoleon_custom_sections = [
+    ('hype', 'params_style'),
+    ('lisflood', 'params_style'),
+    ('marrmot', 'params_style'),
+    ('pcrglobwb', 'params_style'),
+    ('wflow', 'params_style'),
+]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -206,7 +206,7 @@ autodoc_mock_imports = [
     'cftime',
     'dask',
     'esmvalcore',
-    'fiona'
+    'fiona',
     'hydrostats',
     'matplotlib',
     'numpy',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -206,6 +206,7 @@ autodoc_mock_imports = [
     'cftime',
     'dask',
     'esmvalcore',
+    'fiona'
     'hydrostats',
     'matplotlib',
     'numpy',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -208,6 +208,7 @@ autodoc_mock_imports = [
     'esmvalcore',
     'fiona',
     'dateutil',
+    'shapely',
     'hydrostats',
     'matplotlib',
     'numpy',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,25 +191,6 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
-autodoc_mock_imports = [
-    'basic_modeling_interface',
-    'cftime',
-    'dask',
-    'esmvalcore',
-    'fiona',
-    'dateutil',
-    'shapely',
-    'hydrostats',
-    'matplotlib',
-    'numpy',
-    'pandas',
-    'pyoos',
-    'grpc4bmi',
-    'ruamel.yaml',
-    'scipy',
-    'xarray',
-]
-
 # Prevent alphabetic sorting of (@data)class attributes/methods
 autodoc_member_order = 'bysource'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,6 +191,25 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
+autodoc_mock_imports = [
+    'basic_modeling_interface',
+    'cftime',
+    'dask',
+    'esmvalcore',
+    'fiona',
+    'dateutil',
+    'shapely',
+    'hydrostats',
+    'matplotlib',
+    'numpy',
+    'pandas',
+    'pyoos',
+    'grpc4bmi',
+    'ruamel.yaml',
+    'scipy',
+    'xarray',
+]
+
 # Prevent alphabetic sorting of (@data)class attributes/methods
 autodoc_member_order = 'bysource'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,9 +19,16 @@
 import os
 import sys
 
+from ewatercycle.forcing import FORCING_CLASSES
+# The version info for the project you're documenting, acts as replacement for
+# |version| and |release|, also used in various other places throughout the
+# built documents.
+#
+# The short X.Y version.
+from ewatercycle.version import __version__ as version
+
 here = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(os.path.join(here, '..')))
-
 
 # -- General configuration ------------------------------------------------
 
@@ -51,12 +58,7 @@ project = u'ewatercycle'
 copyright = u'2018, Netherlands eScience Center & Delft University of Technology'
 author = u'Stefan Verhoeven'
 
-# The version info for the project you're documenting, acts as replacement for
-# |version| and |release|, also used in various other places throughout the
-# built documents.
-#
-# The short X.Y version.
-from ewatercycle.version import __version__ as version
+
 # The full version, including alpha/beta/rc tags.
 release = version
 
@@ -88,15 +90,8 @@ def run_apidoc(_):
 
     ignore_paths = []
 
-    argv = [
-        "-f",
-        "-T",
-        "-e",
-        "-M",
-        "--implicit-namespaces",
-        "-o", out,
-        src
-    ] + ignore_paths
+    argv = ["-f", "-T", "-e", "-M", "--implicit-namespaces", "-o", out, src
+            ] + ignore_paths
 
     try:
         # Sphinx 1.7+
@@ -144,12 +139,10 @@ html_sidebars = {
     ]
 }
 
-
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'ewatercycle_doc'
-
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -179,16 +172,12 @@ latex_documents = [
      u'Stefan Verhoeven', 'manual'),
 ]
 
-
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'ewatercycle', u'ewatercycle Documentation',
-     [author], 1)
-]
-
+man_pages = [(master_doc, 'ewatercycle', u'ewatercycle Documentation',
+              [author], 1)]
 
 # -- Options for Texinfo output -------------------------------------------
 
@@ -196,8 +185,9 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'ewatercycle', u'ewatercycle Documentation',
-     author, 'ewatercycle', 'Python utilities to gather input files for running a hydrology model',
+    (master_doc, 'ewatercycle', u'ewatercycle Documentation', author,
+     'ewatercycle',
+     'Python utilities to gather input files for running a hydrology model',
      'Miscellaneous'),
 ]
 
@@ -224,10 +214,5 @@ autodoc_mock_imports = [
 autodoc_member_order = 'bysource'
 
 # Nice formatting of model-specific input parameters
-napoleon_custom_sections = [
-    ('hype', 'params_style'),
-    ('lisflood', 'params_style'),
-    ('marrmot', 'params_style'),
-    ('pcrglobwb', 'params_style'),
-    ('wflow', 'params_style'),
-]
+napoleon_custom_sections = [(m, 'params_style')
+                            for m in FORCING_CLASSES.keys()]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,16 +19,9 @@
 import os
 import sys
 
-from ewatercycle.forcing import FORCING_CLASSES
-# The version info for the project you're documenting, acts as replacement for
-# |version| and |release|, also used in various other places throughout the
-# built documents.
-#
-# The short X.Y version.
-from ewatercycle.version import __version__ as version
-
 here = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(os.path.join(here, '..')))
+
 
 # -- General configuration ------------------------------------------------
 
@@ -58,7 +51,12 @@ project = u'ewatercycle'
 copyright = u'2018, Netherlands eScience Center & Delft University of Technology'
 author = u'Stefan Verhoeven'
 
-
+# The version info for the project you're documenting, acts as replacement for
+# |version| and |release|, also used in various other places throughout the
+# built documents.
+#
+# The short X.Y version.
+from ewatercycle.version import __version__ as version
 # The full version, including alpha/beta/rc tags.
 release = version
 
@@ -90,8 +88,15 @@ def run_apidoc(_):
 
     ignore_paths = []
 
-    argv = ["-f", "-T", "-e", "-M", "--implicit-namespaces", "-o", out, src
-            ] + ignore_paths
+    argv = [
+        "-f",
+        "-T",
+        "-e",
+        "-M",
+        "--implicit-namespaces",
+        "-o", out,
+        src
+    ] + ignore_paths
 
     try:
         # Sphinx 1.7+
@@ -139,10 +144,12 @@ html_sidebars = {
     ]
 }
 
+
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'ewatercycle_doc'
+
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -172,12 +179,16 @@ latex_documents = [
      u'Stefan Verhoeven', 'manual'),
 ]
 
+
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, 'ewatercycle', u'ewatercycle Documentation',
-              [author], 1)]
+man_pages = [
+    (master_doc, 'ewatercycle', u'ewatercycle Documentation',
+     [author], 1)
+]
+
 
 # -- Options for Texinfo output -------------------------------------------
 
@@ -185,9 +196,8 @@ man_pages = [(master_doc, 'ewatercycle', u'ewatercycle Documentation',
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'ewatercycle', u'ewatercycle Documentation', author,
-     'ewatercycle',
-     'Python utilities to gather input files for running a hydrology model',
+    (master_doc, 'ewatercycle', u'ewatercycle Documentation',
+     author, 'ewatercycle', 'Python utilities to gather input files for running a hydrology model',
      'Miscellaneous'),
 ]
 
@@ -214,5 +224,10 @@ autodoc_mock_imports = [
 autodoc_member_order = 'bysource'
 
 # Nice formatting of model-specific input parameters
-napoleon_custom_sections = [(m, 'params_style')
-                            for m in FORCING_CLASSES.keys()]
+napoleon_custom_sections = [
+    ('hype', 'params_style'),
+    ('lisflood', 'params_style'),
+    ('marrmot', 'params_style'),
+    ('pcrglobwb', 'params_style'),
+    ('wflow', 'params_style'),
+]

--- a/ewatercycle/forcing/__init__.py
+++ b/ewatercycle/forcing/__init__.py
@@ -150,8 +150,8 @@ def generate(target_model: str,
 
 
 # Append docstrings of with model-specific options to existing docstring
-load_foreign.__doc__ += "".join(
+load_foreign.__doc__ += "".join(  # type:ignore
     [f"\n    {k}: {v.__init__.__doc__}" for k, v in FORCING_CLASSES.items()])
 
-generate.__doc__ += "".join(
+generate.__doc__ += "".join(  # type:ignore
     [f"\n    {k}: {v.generate.__doc__}" for k, v in FORCING_CLASSES.items()])

--- a/ewatercycle/forcing/__init__.py
+++ b/ewatercycle/forcing/__init__.py
@@ -16,41 +16,6 @@ FORCING_CLASSES = {  # not sure how to annotate this
 }
 
 
-def generate(target_model: str,
-             dataset: str,
-             start_time: str,
-             end_time: str,
-             shape: str,
-             model_specific_options: Optional[Dict] = None) -> DefaultForcing:
-    """Generate forcing data with ESMValTool.
-
-    Args:
-        target_model: Name of the model
-        dataset: Name of the source dataset. See :py:data:`.DATASETS`.
-        start_time: Start time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
-        end_time: End time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
-        shape: Path to a shape file. Used for spatial selection.
-        model_specific_options: Model specific recipe settings. See below for the available options for each model.
-
-    Returns:
-        Forcing object, e.g. :obj:`.lisflood.LisfloodForcing`
-
-
-    Model-specific options that can be passed to `generate`:
-    """
-    constructor = FORCING_CLASSES.get(target_model, None)
-    if constructor is None:
-        raise NotImplementedError(
-            f'Target model `{target_model}` is not supported by the eWatercycle forcing generator'
-        )
-    if model_specific_options is None:
-        return constructor.generate(dataset, start_time, end_time, shape)
-    forcing_info = constructor.generate(dataset, start_time, end_time, shape,
-                                        **model_specific_options)
-    forcing_info.save()
-    return forcing_info
-
-
 def load(directory):
     """Load previously generated or imported forcing data.
 
@@ -136,6 +101,39 @@ def load_foreign(target_model,
     return constructor(start_time, end_time, directory, shape, **forcing_info)
 
 
+def generate(target_model: str,
+             dataset: str,
+             start_time: str,
+             end_time: str,
+             shape: str,
+             model_specific_options: Optional[Dict] = None) -> DefaultForcing:
+    """Generate forcing data with ESMValTool.
+
+    Args:
+        target_model: Name of the model
+        dataset: Name of the source dataset. See :py:data:`.DATASETS`.
+        start_time: Start time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
+        end_time: End time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
+        shape: Path to a shape file. Used for spatial selection.
+        model_specific_options: Model specific recipe settings. See below for the available options for each model.
+
+    Returns:
+        Forcing object, e.g. :obj:`.lisflood.LisfloodForcing`
+
+
+    Model-specific options that can be passed to `generate`:
+    """
+    constructor = FORCING_CLASSES.get(target_model, None)
+    if constructor is None:
+        raise NotImplementedError(
+            f'Target model `{target_model}` is not supported by the eWatercycle forcing generator'
+        )
+    if model_specific_options is None:
+        return constructor.generate(dataset, start_time, end_time, shape)
+    forcing_info = constructor.generate(dataset, start_time, end_time, shape,
+                                        **model_specific_options)
+    forcing_info.save()
+    return forcing_info
 # Append docstrings of with model-specific options to existing docstring
 load_foreign.__doc__ += "".join(
     [f"\n    {k}: {v.__init__.__doc__}" for k, v in FORCING_CLASSES.items()])

--- a/ewatercycle/forcing/__init__.py
+++ b/ewatercycle/forcing/__init__.py
@@ -51,7 +51,7 @@ def load_foreign(target_model,
         end_time: End time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
         directory: forcing data directory
         shape: Path to a shape file. Used for spatial selection.
-        forcing_info: Model specific information about forcing
+        forcing_info: Dictionary with model-specific information about forcing
             data. See below for the available options for each model.
 
     Returns:
@@ -115,7 +115,7 @@ def generate(target_model: str,
         start_time: Start time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
         end_time: End time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
         shape: Path to a shape file. Used for spatial selection.
-        model_specific_options: Model specific recipe settings. See below for the available options for each model.
+        model_specific_options: Dictionary with model-specific recipe settings. See below for the available options for each model.
 
     Returns:
         Forcing object, e.g. :obj:`.lisflood.LisfloodForcing`

--- a/ewatercycle/forcing/__init__.py
+++ b/ewatercycle/forcing/__init__.py
@@ -15,14 +15,14 @@ FORCING_CLASSES = {  # not sure how to annotate this
 }
 
 
-def load(directory):
+def load(directory: str) -> DefaultForcing:
     """Load previously generated or imported forcing data.
 
     Args:
         directory: forcing data directory; must contain
-        `ewatercycle_forcing.yaml`
+            `ewatercycle_forcing.yaml` file
 
-    Returns: Forcing object, e.g. :obj:`.marrmot.MarrmotForcing`
+    Returns: Forcing object
     """
     yaml = YAML()
     source = Path(directory) / 'ewatercycle_forcing.yaml'
@@ -46,7 +46,7 @@ def load_foreign(target_model,
 
     Args:
         target_model: Name of the hydrological model for which the forcing will
-        be used
+            be used
         start_time: Start time of forcing in UTC and ISO format string e.g.
             'YYYY-MM-DDTHH:MM:SSZ'.
         end_time: End time of forcing in UTC and ISO format string e.g.
@@ -57,7 +57,7 @@ def load_foreign(target_model,
             data. See below for the available options for each model.
 
     Returns:
-        Forcing object, e.g. :obj:`.hype.HypeForcing`
+        Forcing object
 
     Examples:
 
@@ -113,7 +113,7 @@ def generate(target_model: str,
 
     Args:
         target_model: Name of the model
-        dataset: Name of the source dataset. See :py:data:`.DATASETS`.
+        dataset: Name of the source dataset. See :py:mod:`~.datasets`.
         start_time: Start time of forcing in UTC and ISO format string e.g.
             'YYYY-MM-DDTHH:MM:SSZ'.
         end_time: End time of forcing in UTC and ISO format string e.g.
@@ -123,7 +123,7 @@ def generate(target_model: str,
             See below for the available options for each model.
 
     Returns:
-        Forcing object, e.g. :obj:`.lisflood.LisfloodForcing`
+        Forcing object
 
 
     Model-specific options that can be passed to `generate`:

--- a/ewatercycle/forcing/__init__.py
+++ b/ewatercycle/forcing/__init__.py
@@ -3,16 +3,16 @@ from typing import Optional, Dict
 
 from ruamel.yaml import YAML
 
-from . import default, hype, lisflood, marrmot, pcrglobwb, wflow
+from . import _hype, _lisflood, _marrmot, _pcrglobwb, _wflow
 from .datasets import DATASETS
-from .default import DefaultForcing
+from ._default import DefaultForcing
 
 FORCING_CLASSES = {  # not sure how to annotate this
-    "hype": hype.HypeForcing,
-    "lisflood": lisflood.LisfloodForcing,
-    "marrmot": marrmot.MarrmotForcing,
-    "pcrglobwb": pcrglobwb.PCRGlobWBForcing,
-    "wflow": wflow.WflowForcing,
+    "hype": _hype.HypeForcing,
+    "lisflood": _lisflood.LisfloodForcing,
+    "marrmot": _marrmot.MarrmotForcing,
+    "pcrglobwb": _pcrglobwb.PCRGlobWBForcing,
+    "wflow": _wflow.WflowForcing,
 }
 
 
@@ -30,10 +30,13 @@ def generate(target_model: str,
         start_time: Start time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
         end_time: End time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
         shape: Path to a shape file. Used for spatial selection.
-        **model_specific_options: Model specific recipe settings. See `https://ewatercycle.readtherdocs.io/forcing_generate_options`_.
+        model_specific_options: Model specific recipe settings. See below for the available options for each model.
 
     Returns:
         Forcing object, e.g. :obj:`.lisflood.LisfloodForcing`
+
+
+    Model-specific options that can be passed to `generate`:
     """
     constructor = FORCING_CLASSES.get(target_model, None)
     if constructor is None:
@@ -81,8 +84,7 @@ def load_foreign(target_model,
         directory: forcing data directory
         shape: Path to a shape file. Used for spatial selection.
         forcing_info: Model specific information about forcing
-            data. For each model you can see the available information fields
-            at `https://ewatercycle.readtherdocs.io/forcing_load_info`_.
+            data. See below for the available options for each model.
 
     Returns:
         Forcing object, e.g. :obj:`.hype.HypeForcing`
@@ -120,6 +122,8 @@ def load_foreign(target_model,
                                      'PrefixES0': 'es.nc',
                                      'PrefixET0': 'et.nc'
                                  })
+
+    Model-specific forcing info:
     """
     constructor = FORCING_CLASSES.get(target_model, None)
     if constructor is None:
@@ -128,6 +132,11 @@ def load_foreign(target_model,
     return constructor(start_time, end_time, directory, shape, **forcing_info)
 
 
-# TODO fix time conventions
-# TODO add / fix tests
-# TODO make sure model classes understand new forcing data objects
+# Append docstrings of with model-specific options to existing docstring
+load_foreign.__doc__ += "".join([
+    f"\n    {k}: {v.__init__.__doc__}" for k, v in FORCING_CLASSES.items()
+])
+
+generate.__doc__ += "".join([
+    f"\n    {k}: {v.generate.__doc__}" for k, v in FORCING_CLASSES.items()
+])

--- a/ewatercycle/forcing/__init__.py
+++ b/ewatercycle/forcing/__init__.py
@@ -5,7 +5,6 @@ from ruamel.yaml import YAML
 
 from . import _hype, _lisflood, _marrmot, _pcrglobwb, _wflow
 from ._default import DefaultForcing
-from .datasets import DATASETS
 
 FORCING_CLASSES = {  # not sure how to annotate this
     "hype": _hype.HypeForcing,
@@ -20,10 +19,10 @@ def load(directory):
     """Load previously generated or imported forcing data.
 
     Args:
-        directory: forcing data directory; must contain `ewatercycle_forcing.yaml`
+        directory: forcing data directory; must contain
+        `ewatercycle_forcing.yaml`
 
-    Returns:
-        Forcing object, e.g. :obj:`.marrmot.MarrmotForcing`
+    Returns: Forcing object, e.g. :obj:`.marrmot.MarrmotForcing`
     """
     yaml = YAML()
     source = Path(directory) / 'ewatercycle_forcing.yaml'
@@ -46,9 +45,12 @@ def load_foreign(target_model,
     """Load existing forcing data generated from an external source.
 
     Args:
-        target_model: Name of the hydrological model for which the forcing will be used
-        start_time: Start time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
-        end_time: End time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
+        target_model: Name of the hydrological model for which the forcing will
+        be used
+        start_time: Start time of forcing in UTC and ISO format string e.g.
+            'YYYY-MM-DDTHH:MM:SSZ'.
+        end_time: End time of forcing in UTC and ISO format string e.g.
+            'YYYY-MM-DDTHH:MM:SSZ'.
         directory: forcing data directory
         shape: Path to a shape file. Used for spatial selection.
         forcing_info: Dictionary with model-specific information about forcing
@@ -96,8 +98,8 @@ def load_foreign(target_model,
     constructor = FORCING_CLASSES.get(target_model, None)
     if constructor is None:
         raise NotImplementedError(
-            f'Target model `{target_model}` is not supported by the eWatercycle forcing generator'
-        )
+            f'Target model `{target_model}` is not supported by the '
+            'eWatercycle forcing generator')
     return constructor(start_time, end_time, directory, shape, **forcing_info)
 
 
@@ -112,10 +114,13 @@ def generate(target_model: str,
     Args:
         target_model: Name of the model
         dataset: Name of the source dataset. See :py:data:`.DATASETS`.
-        start_time: Start time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
-        end_time: End time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
+        start_time: Start time of forcing in UTC and ISO format string e.g.
+            'YYYY-MM-DDTHH:MM:SSZ'.
+        end_time: End time of forcing in UTC and ISO format string e.g.
+            'YYYY-MM-DDTHH:MM:SSZ'.
         shape: Path to a shape file. Used for spatial selection.
-        model_specific_options: Dictionary with model-specific recipe settings. See below for the available options for each model.
+        model_specific_options: Dictionary with model-specific recipe settings.
+            See below for the available options for each model.
 
     Returns:
         Forcing object, e.g. :obj:`.lisflood.LisfloodForcing`
@@ -126,14 +131,16 @@ def generate(target_model: str,
     constructor = FORCING_CLASSES.get(target_model, None)
     if constructor is None:
         raise NotImplementedError(
-            f'Target model `{target_model}` is not supported by the eWatercycle forcing generator'
-        )
+            f'Target model `{target_model}` is not supported by the '
+            'eWatercycle forcing generator')
     if model_specific_options is None:
         return constructor.generate(dataset, start_time, end_time, shape)
     forcing_info = constructor.generate(dataset, start_time, end_time, shape,
                                         **model_specific_options)
     forcing_info.save()
     return forcing_info
+
+
 # Append docstrings of with model-specific options to existing docstring
 load_foreign.__doc__ += "".join(
     [f"\n    {k}: {v.__init__.__doc__}" for k, v in FORCING_CLASSES.items()])

--- a/ewatercycle/forcing/__init__.py
+++ b/ewatercycle/forcing/__init__.py
@@ -103,7 +103,11 @@ def load_foreign(target_model,
     if forcing_info is None:
         forcing_info = {}
     return constructor(
-        start_time, end_time, directory, shape, **forcing_info
+        start_time=start_time,
+        end_time=end_time,
+        directory=directory,
+        shape=shape,
+        **forcing_info,
     )  # type: ignore # each subclass can have different forcing_info
 
 

--- a/ewatercycle/forcing/__init__.py
+++ b/ewatercycle/forcing/__init__.py
@@ -102,13 +102,13 @@ def load_foreign(target_model,
             'eWatercycle forcing generator.')
     if forcing_info is None:
         forcing_info = {}
-    return constructor(
+    return constructor(  # type: ignore # each subclass can have different forcing_info
         start_time=start_time,
         end_time=end_time,
         directory=directory,
         shape=shape,
         **forcing_info,
-    )  # type: ignore # each subclass can have different forcing_info
+    )
 
 
 def generate(target_model: str,

--- a/ewatercycle/forcing/__init__.py
+++ b/ewatercycle/forcing/__init__.py
@@ -1,11 +1,11 @@
 from pathlib import Path
-from typing import Optional, Dict
+from typing import Dict, Optional
 
 from ruamel.yaml import YAML
 
 from . import _hype, _lisflood, _marrmot, _pcrglobwb, _wflow
-from .datasets import DATASETS
 from ._default import DefaultForcing
+from .datasets import DATASETS
 
 FORCING_CLASSES = {  # not sure how to annotate this
     "hype": _hype.HypeForcing,
@@ -40,10 +40,13 @@ def generate(target_model: str,
     """
     constructor = FORCING_CLASSES.get(target_model, None)
     if constructor is None:
-        raise NotImplementedError(f'Target model `{target_model}` is not supported by the eWatercycle forcing generator')
+        raise NotImplementedError(
+            f'Target model `{target_model}` is not supported by the eWatercycle forcing generator'
+        )
     if model_specific_options is None:
         return constructor.generate(dataset, start_time, end_time, shape)
-    forcing_info = constructor.generate(dataset, start_time, end_time, shape, **model_specific_options)
+    forcing_info = constructor.generate(dataset, start_time, end_time, shape,
+                                        **model_specific_options)
     forcing_info.save()
     return forcing_info
 
@@ -128,15 +131,14 @@ def load_foreign(target_model,
     constructor = FORCING_CLASSES.get(target_model, None)
     if constructor is None:
         raise NotImplementedError(
-            f'Target model `{target_model}` is not supported by the eWatercycle forcing generator')
+            f'Target model `{target_model}` is not supported by the eWatercycle forcing generator'
+        )
     return constructor(start_time, end_time, directory, shape, **forcing_info)
 
 
 # Append docstrings of with model-specific options to existing docstring
-load_foreign.__doc__ += "".join([
-    f"\n    {k}: {v.__init__.__doc__}" for k, v in FORCING_CLASSES.items()
-])
+load_foreign.__doc__ += "".join(
+    [f"\n    {k}: {v.__init__.__doc__}" for k, v in FORCING_CLASSES.items()])
 
-generate.__doc__ += "".join([
-    f"\n    {k}: {v.generate.__doc__}" for k, v in FORCING_CLASSES.items()
-])
+generate.__doc__ += "".join(
+    [f"\n    {k}: {v.generate.__doc__}" for k, v in FORCING_CLASSES.items()])

--- a/ewatercycle/forcing/_default.py
+++ b/ewatercycle/forcing/_default.py
@@ -34,6 +34,7 @@ class DefaultForcing:
         start_time: str,
         end_time: str,
         shape: str,
+        **model_specific_options,
     ) -> 'DefaultForcing':
         """Generate forcing data with ESMValTool."""
         raise NotImplementedError("No default forcing generator available.")

--- a/ewatercycle/forcing/_default.py
+++ b/ewatercycle/forcing/_default.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from ruamel.yaml import YAML
 
+
 class DefaultForcing:
     """Container for forcing data.
 
@@ -14,19 +15,21 @@ class DefaultForcing:
         end_time: End time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
         shape: Path to a shape file. Used for spatial selection.
     """
-    def __init__(self, start_time: str, end_time: str, directory: str, shape: str):
+    def __init__(self, start_time: str, end_time: str, directory: str,
+                 shape: str):
         self.start_time = parse_time(start_time)
         self.end_time = parse_time(end_time)
         self.directory = parse_path(directory)
         self.shape = parse_path(shape)
 
     @classmethod
-    def generate(cls,
-                 dataset: str,
-                 start_time: str,
-                 end_time: str,
-                 shape: str,
-                 ) -> 'DefaultForcing':
+    def generate(
+        cls,
+        dataset: str,
+        start_time: str,
+        end_time: str,
+        shape: str,
+    ) -> 'DefaultForcing':
         """Generate forcing data with ESMValTool."""
         raise NotImplementedError("No default forcing generator available.")
 

--- a/ewatercycle/forcing/_default.py
+++ b/ewatercycle/forcing/_default.py
@@ -1,10 +1,9 @@
 """Forcing related functionality for default models"""
 
 from pathlib import Path
+from typing import Optional
 
 from ruamel.yaml import YAML
-
-from ewatercycle.util import get_time, parse_path
 
 
 class DefaultForcing:
@@ -18,8 +17,11 @@ class DefaultForcing:
             'YYYY-MM-DDTHH:MM:SSZ'.
         shape: Path to a shape file. Used for spatial selection.
     """
-    def __init__(self, start_time: str, end_time: str, directory: str,
-                 shape: str):
+    def __init__(self,
+                 start_time: str,
+                 end_time: str,
+                 directory: str,
+                 shape: Optional[str] = None):
         self.start_time = start_time
         self.end_time = end_time
         self.directory = directory

--- a/ewatercycle/forcing/_default.py
+++ b/ewatercycle/forcing/_default.py
@@ -50,3 +50,6 @@ class DefaultForcing:
 
     def plot(self):
         raise NotImplementedError("No generic plotting method available.")
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__

--- a/ewatercycle/forcing/_default.py
+++ b/ewatercycle/forcing/_default.py
@@ -5,23 +5,20 @@ from pathlib import Path
 
 from ruamel.yaml import YAML
 
-
-@dataclass
 class DefaultForcing:
-    """Container for forcing data."""
+    """Container for forcing data.
 
-    # Default attributes that every forcing class should have:
-    start_time: str
-    """Start time of the forcing data"""
-    end_time: str
-    """End time of the forcing data"""
-    directory: str = '.'
-    """Location where the forcing data is stored."""
-    shape: str = None
-    """Shape file"""
-
-    # Model-specific attributes (preferably with default values):
-    # ...
+    Args:
+        dataset: Name of the source dataset. See :py:data:`.DATASETS`.
+        start_time: Start time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
+        end_time: End time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
+        shape: Path to a shape file. Used for spatial selection.
+    """
+    def __init__(self, start_time: str, end_time: str, directory: str, shape: str):
+        self.start_time = parse_time(start_time)
+        self.end_time = parse_time(end_time)
+        self.directory = parse_path(directory)
+        self.shape = parse_path(shape)
 
     @classmethod
     def generate(cls,

--- a/ewatercycle/forcing/_default.py
+++ b/ewatercycle/forcing/_default.py
@@ -20,10 +20,10 @@ class DefaultForcing:
     """
     def __init__(self, start_time: str, end_time: str, directory: str,
                  shape: str):
-        self.start_time = get_time(start_time)
-        self.end_time = get_time(end_time)
-        self.directory = parse_path(directory)
-        self.shape = parse_path(shape)
+        self.start_time = start_time
+        self.end_time = end_time
+        self.directory = directory
+        self.shape = shape
 
     @classmethod
     def generate(

--- a/ewatercycle/forcing/_default.py
+++ b/ewatercycle/forcing/_default.py
@@ -1,6 +1,5 @@
 """Forcing related functionality for default models"""
 
-from dataclasses import dataclass
 from pathlib import Path
 
 from ruamel.yaml import YAML

--- a/ewatercycle/forcing/_default.py
+++ b/ewatercycle/forcing/_default.py
@@ -4,20 +4,24 @@ from pathlib import Path
 
 from ruamel.yaml import YAML
 
+from ewatercycle.util import get_time, parse_path
+
 
 class DefaultForcing:
     """Container for forcing data.
 
     Args:
         dataset: Name of the source dataset. See :py:data:`.DATASETS`.
-        start_time: Start time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
-        end_time: End time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
+        start_time: Start time of forcing in UTC and ISO format string e.g.
+            'YYYY-MM-DDTHH:MM:SSZ'.
+        end_time: End time of forcing in UTC and ISO format string e.g.
+            'YYYY-MM-DDTHH:MM:SSZ'.
         shape: Path to a shape file. Used for spatial selection.
     """
     def __init__(self, start_time: str, end_time: str, directory: str,
                  shape: str):
-        self.start_time = parse_time(start_time)
-        self.end_time = parse_time(end_time)
+        self.start_time = get_time(start_time)
+        self.end_time = get_time(end_time)
         self.directory = parse_path(directory)
         self.shape = parse_path(shape)
 

--- a/ewatercycle/forcing/_hype.py
+++ b/ewatercycle/forcing/_hype.py
@@ -1,25 +1,28 @@
 """Forcing related functionality for hype"""
 
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
 from esmvalcore.experimental import get_recipe
 
 from .datasets import DATASETS
-from .default import DefaultForcing
+from ._default import DefaultForcing
 from ..util import get_time
 
-GENERATE_DOCS = """Hype does not have model specific options."""
-LOAD_DOCS = """Hype does not have model specific info."""
-
-
-@dataclass
 class HypeForcing(DefaultForcing):
     """Container for hype forcing data."""
+    def __init__(
+        self,
+        start_time: str,
+        end_time: str,
+        directory: str,
+        shape: str,
+    ):
+        """
+            None: Hype does not have model-specific load options.
+        """
+        super().__init(start_time, end_time, directory, shape)
 
-    # Model-specific attributes (preferably with default values):
-    # ...
 
     @classmethod
     def generate(  # type: ignore
@@ -29,13 +32,8 @@ class HypeForcing(DefaultForcing):
         end_time: str,
         shape: str
     ) -> 'HypeForcing':
-        """Generate HypeForcing with ESMValTool.
-
-        Args:
-            dataset: Name of the source dataset. See :py:data:`.DATASETS`.
-            start_time: Start time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
-            end_time: End time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
-            shape: Path to a shape file. Used for spatial selection.
+        """
+            None: Hype does not have model-specific generate options.
         """
         # load the ESMValTool recipe
         recipe_name = "hydrology/recipe_hype.yml"

--- a/ewatercycle/forcing/_hype.py
+++ b/ewatercycle/forcing/_hype.py
@@ -60,7 +60,7 @@ class HypeForcing(DefaultForcing):
         forcing_path = list(recipe_output['...........']).data_files[0]
 
         forcing_file = Path(forcing_path).name
-        directory = str(Path(forcing_path).parent)
+        directory = str(Path(forcing_file).parent)
 
         # instantiate forcing object based on generated data
         return HypeForcing(directory=directory,

--- a/ewatercycle/forcing/_hype.py
+++ b/ewatercycle/forcing/_hype.py
@@ -17,7 +17,7 @@ class HypeForcing(DefaultForcing):
         start_time: str,
         end_time: str,
         directory: str,
-        shape: str,
+        shape: Optional[str] = None,
     ):
         """
             None: Hype does not have model-specific load options.

--- a/ewatercycle/forcing/_hype.py
+++ b/ewatercycle/forcing/_hype.py
@@ -22,7 +22,7 @@ class HypeForcing(DefaultForcing):
         """
             None: Hype does not have model-specific load options.
         """
-        super().__init(start_time, end_time, directory, shape)
+        super().__init__(start_time, end_time, directory, shape)
 
     @classmethod
     def generate(  # type: ignore

--- a/ewatercycle/forcing/_hype.py
+++ b/ewatercycle/forcing/_hype.py
@@ -5,9 +5,10 @@ from typing import Optional
 
 from esmvalcore.experimental import get_recipe
 
-from .datasets import DATASETS
-from ._default import DefaultForcing
 from ..util import get_time
+from ._default import DefaultForcing
+from .datasets import DATASETS
+
 
 class HypeForcing(DefaultForcing):
     """Container for hype forcing data."""
@@ -23,15 +24,10 @@ class HypeForcing(DefaultForcing):
         """
         super().__init(start_time, end_time, directory, shape)
 
-
     @classmethod
     def generate(  # type: ignore
-        cls,
-        dataset: str,
-        start_time: str,
-        end_time: str,
-        shape: str
-    ) -> 'HypeForcing':
+            cls, dataset: str, start_time: str, end_time: str,
+            shape: str) -> 'HypeForcing':
         """
             None: Hype does not have model-specific generate options.
         """

--- a/ewatercycle/forcing/_lisflood.py
+++ b/ewatercycle/forcing/_lisflood.py
@@ -27,11 +27,16 @@ class LisfloodForcing(DefaultForcing):
         PrefixET0: Optional[str] = 'et0.nc',
     ):
         """
-            PrefixPrecipitation: Path to a NetCDF or pcraster file with precipitation data
-            PrefixTavg: Path to a NetCDF or pcraster file with average temperature data
-            PrefixE0: Path to a NetCDF or pcraster file with potential evaporation rate from open water surface data
-            PrefixES0: Path to a NetCDF or pcraster file with potential evaporation rate from bare soil surface data
-            PrefixET0: Path to a NetCDF or pcraster file with potential (reference) evapotranspiration rate data
+            PrefixPrecipitation: Path to a NetCDF or pcraster file with
+                precipitation data
+            PrefixTavg: Path to a NetCDF or pcraster file with average
+                temperature data
+            PrefixE0: Path to a NetCDF or pcraster file with potential
+                evaporation rate from open water surface data
+            PrefixES0: Path to a NetCDF or pcraster file with potential
+                evaporation rate from bare soil surface data
+            PrefixET0: Path to a NetCDF or pcraster file with potential
+                (reference) evapotranspiration rate data
         """
         super().__init__(start_time, end_time, directory, shape)
         self.PrefixPrecipitation = PrefixPrecipitation

--- a/ewatercycle/forcing/_lisflood.py
+++ b/ewatercycle/forcing/_lisflood.py
@@ -1,40 +1,41 @@
 """Forcing related functionality for lisflood"""
 
-from dataclasses import dataclass
 from pathlib import Path
 
 from esmvalcore.experimental import get_recipe
-
+from typing import Optional
 from .datasets import DATASETS
-from .default import DefaultForcing
+from ._default import DefaultForcing
 from ..util import get_time, get_extents, data_files_from_recipe_output
 
-GENERATE_DOCS = """
-Options:
-    extract_region (dict): Region specification, dictionary must contain `start_longitude`,
-        `end_longitude`, `start_latitude`, `end_latitude`
-"""
-LOAD_DOCS = """
-Fields:
-    PrefixPrecipitation: Path to a NetCDF or pcraster file with precipitation data
-    PrefixTavg: Path to a NetCDF or pcraster file with average temperature data
-    PrefixE0: Path to a NetCDF or pcraster file with potential evaporation rate from open water surface data
-    PrefixES0: Path to a NetCDF or pcraster file with potential evaporation rate from bare soil surface data
-    PrefixET0: Path to a NetCDF or pcraster file with potential (reference) evapotranspiration rate data
-"""
-
-
-@dataclass
 class LisfloodForcing(DefaultForcing):
     """Container for lisflood forcing data."""
-
-    # Model-specific attributes (preferably with default values):
-    PrefixPrecipitation: str = 'pr.nc'
-    PrefixTavg: str = 'tas.nc'
-    PrefixE0: str = 'e0.nc'
-    PrefixES0: str = 'es0.nc'
-    PrefixET0: str = 'et0.nc'
     # TODO check whether start/end time are same as in the files
+    def __init__(
+        self,
+        start_time: str,
+        end_time: str,
+        directory: str,
+        shape: str,
+        PrefixPrecipitation: Optional[str] = 'pr.nc',
+        PrefixTavg: Optional[str] = 'tas.nc',
+        PrefixE0: Optional[str] = 'e0.nc',
+        PrefixES0: Optional[str] = 'es0.nc',
+        PrefixET0: Optional[str] = 'et0.nc',
+    ):
+        """
+            PrefixPrecipitation: Path to a NetCDF or pcraster file with precipitation data
+            PrefixTavg: Path to a NetCDF or pcraster file with average temperature data
+            PrefixE0: Path to a NetCDF or pcraster file with potential evaporation rate from open water surface data
+            PrefixES0: Path to a NetCDF or pcraster file with potential evaporation rate from bare soil surface data
+            PrefixET0: Path to a NetCDF or pcraster file with potential (reference) evapotranspiration rate data
+        """
+        super().__init(start_time, end_time, directory, shape)
+        self.PrefixPrecipitation = PrefixPrecipitation
+        self.PrefixTavg = PrefixTavg
+        self.PrefixE0 = PrefixE0
+        self.PrefixES0 = PrefixES0
+        self.PrefixET0 = PrefixET0
 
     @classmethod
     def generate(  # type: ignore
@@ -45,18 +46,9 @@ class LisfloodForcing(DefaultForcing):
         shape: str,
         extract_region: dict = None,
     ) -> 'LisfloodForcing':
-        """Generate LisfloodForcing with ESMValTool.
-
-        Args:
-            dataset: Name of the source dataset. See :py:data:`.DATASETS`.
-            start_time: Start time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
-            end_time: End time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
-            shape: Path to a shape file. Used for spatial selection.
-            extract_region: Region specification, must contain `start_longitude`,
+        """
+            extract_region (dict): Region specification, dictionary must contain `start_longitude`,
                 `end_longitude`, `start_latitude`, `end_latitude`
-
-            TODO add regrid options so forcing can be generated for parameter set
-            TODO that is not on a 0.1x0.1 grid
         """
         # load the ESMValTool recipe
         recipe_name = "hydrology/recipe_hype.yml"

--- a/ewatercycle/forcing/_lisflood.py
+++ b/ewatercycle/forcing/_lisflood.py
@@ -19,7 +19,7 @@ class LisfloodForcing(DefaultForcing):
         start_time: str,
         end_time: str,
         directory: str,
-        shape: str,
+        shape: Optional[str] = None,
         PrefixPrecipitation: Optional[str] = 'pr.nc',
         PrefixTavg: Optional[str] = 'tas.nc',
         PrefixE0: Optional[str] = 'e0.nc',
@@ -103,15 +103,16 @@ class LisfloodForcing(DefaultForcing):
         # TODO forcing_files['e0'] = ...
 
         # instantiate forcing object based on generated data
-        return LisfloodForcing(directory=directory,
-                               start_time=start_time,
-                               end_time=end_time,
-                               PrefixPrecipitation=forcing_files["pr"],
-                               PrefixTavg=forcing_files["tas"],
-                               PrefixE0=forcing_files['e0'],
-                               PrefixES0=forcing_files['es0'],
-                               PrefixET0=forcing_files['et0'],
-                               )
+        return LisfloodForcing(
+            directory=directory,
+            start_time=start_time,
+            end_time=end_time,
+            PrefixPrecipitation=forcing_files["pr"],
+            PrefixTavg=forcing_files["tas"],
+            PrefixE0=forcing_files['e0'],
+            PrefixES0=forcing_files['es0'],
+            PrefixET0=forcing_files['et0'],
+        )
 
     def plot(self):
         raise NotImplementedError('Dont know how to plot')

--- a/ewatercycle/forcing/_lisflood.py
+++ b/ewatercycle/forcing/_lisflood.py
@@ -33,7 +33,7 @@ class LisfloodForcing(DefaultForcing):
             PrefixES0: Path to a NetCDF or pcraster file with potential evaporation rate from bare soil surface data
             PrefixET0: Path to a NetCDF or pcraster file with potential (reference) evapotranspiration rate data
         """
-        super().__init(start_time, end_time, directory, shape)
+        super().__init__(start_time, end_time, directory, shape)
         self.PrefixPrecipitation = PrefixPrecipitation
         self.PrefixTavg = PrefixTavg
         self.PrefixE0 = PrefixE0

--- a/ewatercycle/forcing/_lisflood.py
+++ b/ewatercycle/forcing/_lisflood.py
@@ -1,15 +1,18 @@
 """Forcing related functionality for lisflood"""
 
 from pathlib import Path
+from typing import Optional
 
 from esmvalcore.experimental import get_recipe
-from typing import Optional
-from .datasets import DATASETS
+
+from ..util import data_files_from_recipe_output, get_extents, get_time
 from ._default import DefaultForcing
-from ..util import get_time, get_extents, data_files_from_recipe_output
+from .datasets import DATASETS
+
 
 class LisfloodForcing(DefaultForcing):
     """Container for lisflood forcing data."""
+
     # TODO check whether start/end time are same as in the files
     def __init__(
         self,
@@ -62,13 +65,14 @@ class LisfloodForcing(DefaultForcing):
         for preproc_name in preproc_names:
             recipe.data['preprocessors'][preproc_name]['extract_shape'][
                 'shapefile'] = shape
-        recipe.data['diagnostics']['diagnostic_daily']['scripts'][
-            'script']['catchment'] = basin
+        recipe.data['diagnostics']['diagnostic_daily']['scripts']['script'][
+            'catchment'] = basin
 
         if extract_region is None:
             extract_region = get_extents(shape)
         for preproc_name in preproc_names:
-            recipe.data['preprocessors'][preproc_name]['extract_region'] = extract_region
+            recipe.data['preprocessors'][preproc_name][
+                'extract_region'] = extract_region
 
         recipe.data['datasets'] = [DATASETS[dataset]]
 
@@ -91,15 +95,16 @@ class LisfloodForcing(DefaultForcing):
         # TODO forcing_files['e0'] = ...
 
         # instantiate forcing object based on generated data
-        return LisfloodForcing(directory=directory,
-                               start_time=str(startyear),
-                               end_time=str(endyear),
-                               PrefixPrecipitation=forcing_files["pr"],
-                               PrefixTavg=forcing_files["tas"],
-                               PrefixE0=forcing_files['e0'],
-                               PrefixES0=forcing_files['es0'],
-                               PrefixET0=forcing_files['et0'],
-                               )
+        return LisfloodForcing(
+            directory=directory,
+            start_time=str(startyear),
+            end_time=str(endyear),
+            PrefixPrecipitation=forcing_files["pr"],
+            PrefixTavg=forcing_files["tas"],
+            PrefixE0=forcing_files['e0'],
+            PrefixES0=forcing_files['es0'],
+            PrefixET0=forcing_files['et0'],
+        )
 
     def plot(self):
         raise NotImplementedError('Dont know how to plot')

--- a/ewatercycle/forcing/_marrmot.py
+++ b/ewatercycle/forcing/_marrmot.py
@@ -23,7 +23,7 @@ class MarrmotForcing(DefaultForcing):
         """
             forcing_file: Matlab file that contains forcings for Marrmot models. See format forcing file in `model implementation <https://github.com/wknoben/MARRMoT/blob/8f7e80979c2bef941c50f2fb19ce4998e7b273b0/BMI/lib/marrmotBMI_oct.m#L15-L19>`_.
         """
-        super().__init(start_time, end_time, directory, shape)
+        super().__init__(start_time, end_time, directory, shape)
         self.forcing_file = forcing_file
 
     @classmethod

--- a/ewatercycle/forcing/_marrmot.py
+++ b/ewatercycle/forcing/_marrmot.py
@@ -1,12 +1,13 @@
 """Forcing related functionality for marrmot"""
 
 from pathlib import Path
+from typing import Optional
 
 from esmvalcore.experimental import get_recipe
-from typing import Optional
-from .datasets import DATASETS
-from ._default import DefaultForcing
+
 from ..util import get_time
+from ._default import DefaultForcing
+from .datasets import DATASETS
 
 
 class MarrmotForcing(DefaultForcing):
@@ -45,8 +46,8 @@ class MarrmotForcing(DefaultForcing):
         basin = Path(shape).stem
         recipe.data['preprocessors']['daily']['extract_shape'][
             'shapefile'] = shape
-        recipe.data['diagnostics']['diagnostic_daily']['scripts'][
-            'script']['basin'] = basin
+        recipe.data['diagnostics']['diagnostic_daily']['scripts']['script'][
+            'basin'] = basin
 
         recipe.data['diagnostics']['diagnostic_daily'][
             'additional_datasets'] = [DATASETS[dataset]]

--- a/ewatercycle/forcing/_marrmot.py
+++ b/ewatercycle/forcing/_marrmot.py
@@ -1,27 +1,29 @@
 """Forcing related functionality for marrmot"""
 
-from dataclasses import dataclass
 from pathlib import Path
 
 from esmvalcore.experimental import get_recipe
-
+from typing import Optional
 from .datasets import DATASETS
-from .default import DefaultForcing
+from ._default import DefaultForcing
 from ..util import get_time
 
-GENERATE_DOCS = """Marrmot does not have model specific options."""
-LOAD_DOCS = """
-Fields:
-    forcing_file: Matlab file that contains forcings for Marrmot models. See format forcing file in `model implementation <https://github.com/wknoben/MARRMoT/blob/8f7e80979c2bef941c50f2fb19ce4998e7b273b0/BMI/lib/marrmotBMI_oct.m#L15-L19>`_.
-"""
 
-
-@dataclass
 class MarrmotForcing(DefaultForcing):
     """Container for marrmot forcing data."""
-
-    # Model-specific attributes (preferably with default values):
-    forcing_file: str = 'marrmot.mat'
+    def __init__(
+        self,
+        start_time: str,
+        end_time: str,
+        directory: str,
+        shape: str,
+        forcing_file: Optional[str] = 'marrmot.mat',
+    ):
+        """
+            forcing_file: Matlab file that contains forcings for Marrmot models. See format forcing file in `model implementation <https://github.com/wknoben/MARRMoT/blob/8f7e80979c2bef941c50f2fb19ce4998e7b273b0/BMI/lib/marrmotBMI_oct.m#L15-L19>`_.
+        """
+        super().__init(start_time, end_time, directory, shape)
+        self.forcing_file = forcing_file
 
     @classmethod
     def generate(  # type: ignore
@@ -31,14 +33,10 @@ class MarrmotForcing(DefaultForcing):
         end_time: str,
         shape: str,
     ) -> 'MarrmotForcing':
-        """Generate Marrmot forcing data with ESMValTool.
-
-        Args:
-            dataset: Name of the source dataset. See :py:data:`.DATASETS`.
-            start_time: Start time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
-            end_time: End time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
-            shape: Path to a shape file. Used for spatial selection.
         """
+            None: Marrmot does not have model-specific generate options.
+        """
+
         # load the ESMValTool recipe
         recipe_name = "hydrology/recipe_marrmot.yml"
         recipe = get_recipe(recipe_name)

--- a/ewatercycle/forcing/_marrmot.py
+++ b/ewatercycle/forcing/_marrmot.py
@@ -17,8 +17,8 @@ class MarrmotForcing(DefaultForcing):
         start_time: str,
         end_time: str,
         directory: str,
-        forcing_file: str,
         shape: Optional[str] = None,
+        forcing_file: Optional[str] = 'marrmot.mat',
     ):
         """
             forcing_file: Matlab file that contains forcings for Marrmot

--- a/ewatercycle/forcing/_marrmot.py
+++ b/ewatercycle/forcing/_marrmot.py
@@ -17,8 +17,8 @@ class MarrmotForcing(DefaultForcing):
         start_time: str,
         end_time: str,
         directory: str,
-        shape: str,
         forcing_file: str,
+        shape: Optional[str] = None,
     ):
         """
             forcing_file: Matlab file that contains forcings for Marrmot

--- a/ewatercycle/forcing/_marrmot.py
+++ b/ewatercycle/forcing/_marrmot.py
@@ -21,7 +21,9 @@ class MarrmotForcing(DefaultForcing):
         forcing_file: Optional[str] = 'marrmot.mat',
     ):
         """
-            forcing_file: Matlab file that contains forcings for Marrmot models. See format forcing file in `model implementation <https://github.com/wknoben/MARRMoT/blob/8f7e80979c2bef941c50f2fb19ce4998e7b273b0/BMI/lib/marrmotBMI_oct.m#L15-L19>`_.
+            forcing_file: Matlab file that contains forcings for Marrmot
+                models. See format forcing file in `model implementation
+                <https://github.com/wknoben/MARRMoT/blob/8f7e80979c2bef941c50f2fb19ce4998e7b273b0/BMI/lib/marrmotBMI_oct.m#L15-L19>`_.
         """
         super().__init__(start_time, end_time, directory, shape)
         self.forcing_file = forcing_file

--- a/ewatercycle/forcing/_marrmot.py
+++ b/ewatercycle/forcing/_marrmot.py
@@ -18,7 +18,7 @@ class MarrmotForcing(DefaultForcing):
         end_time: str,
         directory: str,
         shape: str,
-        forcing_file: Optional[str] = 'marrmot.mat',
+        forcing_file: str,
     ):
         """
             forcing_file: Matlab file that contains forcings for Marrmot

--- a/ewatercycle/forcing/_pcrglobwb.py
+++ b/ewatercycle/forcing/_pcrglobwb.py
@@ -3,15 +3,16 @@
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
+
 from esmvalcore.experimental import get_recipe
 
-from .datasets import DATASETS
+from ..util import data_files_from_recipe_output, get_extents, get_time
 from ._default import DefaultForcing
-from ..util import get_time, get_extents, data_files_from_recipe_output
+from .datasets import DATASETS
+
 
 class PCRGlobWBForcing(DefaultForcing):
     """Container for pcrglobwb forcing data."""
-
     def __init__(
         self,
         start_time: str,
@@ -26,7 +27,7 @@ class PCRGlobWBForcing(DefaultForcing):
             temperatureNC (str): Input file for temperature data.
         """
         super().__init(start_time, end_time, directory, shape)
-        self.precipitationNC =  precipitationNC
+        self.precipitationNC = precipitationNC
         self.temperatureNC = temperatureNC
 
     @classmethod
@@ -37,7 +38,8 @@ class PCRGlobWBForcing(DefaultForcing):
         end_time: str,
         shape: str,
         start_time_climatology: str,  # TODO make optional, default to start_time
-        end_time_climatology: str,  # TODO make optional, defaults to start_time + 1 year
+        end_time_climatology:
+        str,  # TODO make optional, defaults to start_time + 1 year
         extract_region: dict = None,
     ) -> 'PCRGlobWBForcing':
         """
@@ -59,8 +61,8 @@ class PCRGlobWBForcing(DefaultForcing):
                 'additional_datasets'] = [DATASETS[dataset]]
 
         basin = Path(shape).stem
-        recipe.data['diagnostics']['diagnostic_daily']['scripts'][
-            'script']['basin'] = basin
+        recipe.data['diagnostics']['diagnostic_daily']['scripts']['script'][
+            'basin'] = basin
 
         if extract_region is None:
             extract_region = get_extents(shape)

--- a/ewatercycle/forcing/_pcrglobwb.py
+++ b/ewatercycle/forcing/_pcrglobwb.py
@@ -26,7 +26,7 @@ class PCRGlobWBForcing(DefaultForcing):
             precipitationNC (str): Input file for precipitation data.
             temperatureNC (str): Input file for temperature data.
         """
-        super().__init(start_time, end_time, directory, shape)
+        super().__init__(start_time, end_time, directory, shape)
         self.precipitationNC = precipitationNC
         self.temperatureNC = temperatureNC
 

--- a/ewatercycle/forcing/_pcrglobwb.py
+++ b/ewatercycle/forcing/_pcrglobwb.py
@@ -17,7 +17,7 @@ class PCRGlobWBForcing(DefaultForcing):
         start_time: str,
         end_time: str,
         directory: str,
-        shape: str,
+        shape: Optional[str] = None,
         precipitationNC: Optional[str] = 'precipitation.nc',
         temperatureNC: Optional[str] = 'temperature.nc',
     ):

--- a/ewatercycle/forcing/_pcrglobwb.py
+++ b/ewatercycle/forcing/_pcrglobwb.py
@@ -2,36 +2,32 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-
+from typing import Optional
 from esmvalcore.experimental import get_recipe
 
 from .datasets import DATASETS
-from .default import DefaultForcing
+from ._default import DefaultForcing
 from ..util import get_time, get_extents, data_files_from_recipe_output
 
-GENERATE_DOCS = """
-Options:
-    start_time_climatology (str): Start time for the climatology data
-    end_time_climatology (str): End time for the climatology data
-    extract_region (dict): Region specification, dictionary must contain `start_longitude`,
-        `end_longitude`, `start_latitude`, `end_latitude`
-"""
-LOAD_DOCS = """
-Fields:
-    precipitationNC (str): Input file for precipitation data.
-    temperatureNC (str): Input file for temperature data.
-"""
-
-
-@dataclass
 class PCRGlobWBForcing(DefaultForcing):
     """Container for pcrglobwb forcing data."""
 
-    # Model-specific attributes (preferably with default values):
-    precipitationNC: str = 'pr.nc'
-    """Input file for precipitation data."""
-    temperatureNC: str = 'tas.nc'
-    """Input file for temperature data."""
+    def __init__(
+        self,
+        start_time: str,
+        end_time: str,
+        directory: str,
+        shape: str,
+        precipitationNC: Optional[str] = 'precipitation.nc',
+        temperatureNC: Optional[str] = 'temperature.nc',
+    ):
+        """
+            precipitationNC (str): Input file for precipitation data.
+            temperatureNC (str): Input file for temperature data.
+        """
+        super().__init(start_time, end_time, directory, shape)
+        self.precipitationNC =  precipitationNC
+        self.temperatureNC = temperatureNC
 
     @classmethod
     def generate(  # type: ignore
@@ -44,16 +40,10 @@ class PCRGlobWBForcing(DefaultForcing):
         end_time_climatology: str,  # TODO make optional, defaults to start_time + 1 year
         extract_region: dict = None,
     ) -> 'PCRGlobWBForcing':
-        """Generate WflowForcing data with ESMValTool.
-
-        Args:
-            dataset: Name of the source dataset. See :py:data:`.DATASETS`.
-            start_time: Start time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
-            end_time: End time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
-            shape: Path to a shape file. Used for spatial selection.
-            start_time_climatology: Start time for the climatology data
-            end_time_climatology: End time for the climatology data
-            extract_region: Region specification, must contain `start_longitude`,
+        """
+            start_time_climatology (str): Start time for the climatology data
+            end_time_climatology (str): End time for the climatology data
+            extract_region (dict): Region specification, dictionary must contain `start_longitude`,
                 `end_longitude`, `start_latitude`, `end_latitude`
         """
         # load the ESMValTool recipe

--- a/ewatercycle/forcing/_pcrglobwb.py
+++ b/ewatercycle/forcing/_pcrglobwb.py
@@ -1,6 +1,5 @@
 """Forcing related functionality for pcrglobwb"""
 
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -45,8 +44,9 @@ class PCRGlobWBForcing(DefaultForcing):
         """
             start_time_climatology (str): Start time for the climatology data
             end_time_climatology (str): End time for the climatology data
-            extract_region (dict): Region specification, dictionary must contain `start_longitude`,
-                `end_longitude`, `start_latitude`, `end_latitude`
+            extract_region (dict): Region specification, dictionary must
+                contain `start_longitude`, `end_longitude`, `start_latitude`,
+                `end_latitude`
         """
         # load the ESMValTool recipe
         recipe_name = "hydrology/recipe_pcrglobwb.yml"

--- a/ewatercycle/forcing/_wflow.py
+++ b/ewatercycle/forcing/_wflow.py
@@ -24,11 +24,14 @@ class WflowForcing(DefaultForcing):
         Inflow: Optional[str] = None,
     ):
         """
-            netcdfinput (str): Path to forcing file. Default is "inmaps.nc"
-            Precipitation (str): Variable name of precipitation data in input file. Default is "/pr".
-            EvapoTranspiration (str): Variable name of evapotranspiration data in input file. Default is"/pet".
-            Temperature (str): Variable name of temperature data in input file. Default is "/tas".
-            Inflow (str): Variable name of inflow data in input file. Default is None
+            netcdfinput (str) = "inmaps.nc": Path to forcing file."
+            Precipitation (str) = "/pr": Variable name of precipitation data in
+                input file.
+            EvapoTranspiration (str) = "/pet": Variable name of
+                evapotranspiration data in input file.
+            Temperature (str) = "/tas": Variable name of temperature data in
+                input file.
+            Inflow (str) = None: Variable name of inflow data in input file.
         """
         super().__init__(start_time, end_time, directory, shape)
         self.netcdfinput = netcdfinput
@@ -48,9 +51,11 @@ class WflowForcing(DefaultForcing):
         extract_region: Optional[str] = None,
     ) -> 'WflowForcing':
         """
-            dem_file (str): Name of the dem_file to use. Also defines the basin param.
-            extract_region (dict): Region specification, dictionary must contain `start_longitude`,
-                `end_longitude`, `start_latitude`, `end_latitude`
+            dem_file (str): Name of the dem_file to use. Also defines the basin
+                param.
+            extract_region (dict): Region specification, dictionary must
+                contain `start_longitude`, `end_longitude`, `start_latitude`,
+                `end_latitude`
         """
         # load the ESMValTool recipe
         recipe_name = "hydrology/recipe_wflow.yml"

--- a/ewatercycle/forcing/_wflow.py
+++ b/ewatercycle/forcing/_wflow.py
@@ -4,9 +4,10 @@ from typing import Optional
 
 from esmvalcore.experimental import get_recipe
 
-from .datasets import DATASETS
+from ..util import get_extents, get_time
 from ._default import DefaultForcing
-from ..util import get_time, get_extents
+from .datasets import DATASETS
+
 
 class WflowForcing(DefaultForcing):
     """Container for wflow forcing data."""
@@ -56,12 +57,11 @@ class WflowForcing(DefaultForcing):
         recipe = get_recipe(recipe_name)
 
         basin = Path(shape).stem
-        recipe.data['diagnostics']['wflow_daily']['scripts'][
-            'script']['basin'] = basin
+        recipe.data['diagnostics']['wflow_daily']['scripts']['script'][
+            'basin'] = basin
 
         # model-specific updates
-        script = recipe.data['diagnostics']['wflow_daily']['scripts'][
-            'script']
+        script = recipe.data['diagnostics']['wflow_daily']['scripts']['script']
         script['dem_file'] = dem_file
 
         if extract_region is None:
@@ -69,8 +69,9 @@ class WflowForcing(DefaultForcing):
         recipe.data['preprocessors']['rough_cutout'][
             'extract_region'] = extract_region
 
-        recipe.data['diagnostics']['wflow_daily'][
-            'additional_datasets'] = [DATASETS[dataset]]
+        recipe.data['diagnostics']['wflow_daily']['additional_datasets'] = [
+            DATASETS[dataset]
+        ]
 
         variables = recipe.data['diagnostics']['wflow_daily']['variables']
         var_names = 'tas', 'pr', 'psl', 'rsds', 'rsdt'

--- a/ewatercycle/forcing/_wflow.py
+++ b/ewatercycle/forcing/_wflow.py
@@ -30,7 +30,7 @@ class WflowForcing(DefaultForcing):
             Temperature (str): Variable name of temperature data in input file. Default is "/tas".
             Inflow (str): Variable name of inflow data in input file. Default is None
         """
-        super().__init(start_time, end_time, directory, shape)
+        super().__init__(start_time, end_time, directory, shape)
         self.netcdfinput = netcdfinput
         self.Precipitation = Precipitation
         self.EvapoTranspiration = EvapoTranspiration

--- a/ewatercycle/forcing/_wflow.py
+++ b/ewatercycle/forcing/_wflow.py
@@ -1,6 +1,6 @@
 """Forcing related functionality for wflow"""
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 
 from esmvalcore.experimental import get_recipe
 
@@ -41,14 +41,14 @@ class WflowForcing(DefaultForcing):
         self.Inflow = Inflow
 
     @classmethod
-    def generate(
-        cls,  # type: ignore
+    def generate(  # type: ignore
+        cls,
         dataset: str,
         start_time: str,
         end_time: str,
         shape: str,
         dem_file: str,
-        extract_region: Optional[str] = None,
+        extract_region: Dict[str, float] = None,
     ) -> 'WflowForcing':
         """
             dem_file (str): Name of the dem_file to use. Also defines the basin

--- a/ewatercycle/forcing/_wflow.py
+++ b/ewatercycle/forcing/_wflow.py
@@ -16,7 +16,7 @@ class WflowForcing(DefaultForcing):
         start_time: str,
         end_time: str,
         directory: str,
-        shape: str,
+        shape: Optional[str] = None,
         netcdfinput: Optional[str] = "inmaps.nc",
         Precipitation: Optional[str] = "/pr",
         EvapoTranspiration: Optional[str] = "/pet",

--- a/ewatercycle/forcing/_wflow.py
+++ b/ewatercycle/forcing/_wflow.py
@@ -1,46 +1,40 @@
 """Forcing related functionality for wflow"""
-
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
 from esmvalcore.experimental import get_recipe
 
 from .datasets import DATASETS
-from .default import DefaultForcing
+from ._default import DefaultForcing
 from ..util import get_time, get_extents
 
-GENERATE_DOCS = """
-Options:
-    dem_file (str): Name of the dem_file to use. Also defines the basin param.
-    extract_region (dict): Region specification, dictionary must contain `start_longitude`,
-        `end_longitude`, `start_latitude`, `end_latitude`
-"""
-LOAD_DOCS = """
-Fields:
-    netcdfinput (str): Path to forcing file. Default is "inmaps.nc"
-    Precipitation (str): Variable name of precipitation data in input file. Default is "/pr".
-    EvapoTranspiration (str): Variable name of evapotranspiration data in input file. Default is"/pet".
-    Temperature (str): Variable name of temperature data in input file. Default is "/tas".
-    Inflow Optional[str]: Variable name of inflow data in input file.
-"""
-
-
-@dataclass
 class WflowForcing(DefaultForcing):
     """Container for wflow forcing data."""
-
-    # Model-specific attributes (ideally should have defaults):
-    netcdfinput: str = "inmaps.nc"
-    """Input file path."""
-    Precipitation: str = "/pr"
-    """Variable name of precipitation data in input file."""
-    EvapoTranspiration: str = "/pet"
-    """Variable name of evapotranspiration data in input file."""
-    Temperature: str = "/tas"
-    """Variable name of temperature data in input file."""
-    Inflow: Optional[str] = None
-    """Variable name of inflow data in input file."""
+    def __init__(
+        self,
+        start_time: str,
+        end_time: str,
+        directory: str,
+        shape: str,
+        netcdfinput: Optional[str] = "inmaps.nc",
+        Precipitation: Optional[str] = "/pr",
+        EvapoTranspiration: Optional[str] = "/pet",
+        Temperature: Optional[str] = "/tas",
+        Inflow: Optional[str] = None,
+    ):
+        """
+            netcdfinput (str): Path to forcing file. Default is "inmaps.nc"
+            Precipitation (str): Variable name of precipitation data in input file. Default is "/pr".
+            EvapoTranspiration (str): Variable name of evapotranspiration data in input file. Default is"/pet".
+            Temperature (str): Variable name of temperature data in input file. Default is "/tas".
+            Inflow (str): Variable name of inflow data in input file. Default is None
+        """
+        super().__init(start_time, end_time, directory, shape)
+        self.netcdfinput = netcdfinput
+        self.Precipitation = Precipitation
+        self.EvapoTranspiration = EvapoTranspiration
+        self.Temperature = Temperature
+        self.Inflow = Inflow
 
     @classmethod
     def generate(
@@ -52,16 +46,10 @@ class WflowForcing(DefaultForcing):
         dem_file: str,
         extract_region: Optional[str] = None,
     ) -> 'WflowForcing':
-        """Generate WflowForcing data with ESMValTool.
-
-        Args:
-            dataset: Name of the source dataset. See :py:data:`.DATASETS`.
-            start_time: Start time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
-            end_time: End time of forcing in UTC and ISO format string e.g. 'YYYY-MM-DDTHH:MM:SSZ'.
-            shape: Path to a shape file. Used for spatial selection.
-            extract_region: Region specification, must contain `start_longitude`,
+        """
+            dem_file (str): Name of the dem_file to use. Also defines the basin param.
+            extract_region (dict): Region specification, dictionary must contain `start_longitude`,
                 `end_longitude`, `start_latitude`, `end_latitude`
-            dem_file: Name of the dem_file to use. Also defines the basin param.
         """
         # load the ESMValTool recipe
         recipe_name = "hydrology/recipe_wflow.yml"

--- a/ewatercycle/forcing/datasets.py
+++ b/ewatercycle/forcing/datasets.py
@@ -1,3 +1,8 @@
+"""Supported datasets for ESMValTool recipes.
+
+Currently supported: ERA5 and ERA-Interim.
+"""
+
 DATASETS = {
     'ERA5': {
         'dataset': 'ERA5',

--- a/ewatercycle/models/lisflood.py
+++ b/ewatercycle/models/lisflood.py
@@ -11,7 +11,7 @@ from grpc4bmi.bmi_client_docker import BmiClientDocker
 from grpc4bmi.bmi_client_singularity import BmiClientSingularity
 
 from ewatercycle import CFG
-from ewatercycle.forcing.lisflood import LisfloodForcing
+from ewatercycle.forcing._lisflood import LisfloodForcing
 from ewatercycle.models.abstract import AbstractModel
 from ewatercycle.parametersetdb.config import AbstractConfig
 from ewatercycle.util import get_time

--- a/ewatercycle/models/marrmot.py
+++ b/ewatercycle/models/marrmot.py
@@ -11,7 +11,7 @@ from grpc4bmi.bmi_client_docker import BmiClientDocker
 from grpc4bmi.bmi_client_singularity import BmiClientSingularity
 
 from ewatercycle import CFG
-from ewatercycle.forcing.marrmot import MarrmotForcing
+from ewatercycle.forcing._marrmot import MarrmotForcing
 from ewatercycle.models.abstract import AbstractModel
 from ewatercycle.util import get_time
 

--- a/ewatercycle/models/pcrglobwb.py
+++ b/ewatercycle/models/pcrglobwb.py
@@ -1,8 +1,7 @@
-import shutil
 import time
 from os import PathLike
 from pathlib import Path
-from typing import Any, Iterable, Optional, Tuple
+from typing import Any, Iterable, Tuple
 
 import numpy as np
 import xarray as xr

--- a/ewatercycle/models/pcrglobwb.py
+++ b/ewatercycle/models/pcrglobwb.py
@@ -29,23 +29,20 @@ class PCRGlobWB(AbstractModel):
         """Start model inside container and return config file and work dir.
 
         Args:
-
-            - input_dir: main input directory. Relative paths in the cfg_file
-            should start from this directory.
-
-            - cfg_file: path to a valid pcrglobwb configuration file,
+            input_dir: main input directory. Relative paths in the cfg_file
+                should start from this directory.
+            cfg_file: path to a valid pcrglobwb configuration file,
             typically somethig like `setup.ini`.
+            additional_input_dirs: one or more additional data directories
+                that the model will have access to.
+            **kwargs (optional, dict): any settings in the cfg_file that you
+                want to overwrite programmatically. Should be passed as a dict,
+                e.g. `meteoOptions = {"temperatureNC": "era5_tas_1990_2000.nc"}`
+                where meteoOptions is the section in which the temperatureNC option
+                may be found.
 
-            - additional_input_dirs: one or more additional data directories
-            that the model will have access to.
-
-            - **kwargs (optional, dict): any settings in the cfg_file that you
-            want to overwrite programmatically. Should be passed as a dict,
-            e.g. `meteoOptions = {"temperatureNC": "era5_tas_1990_2000.nc"}`
-            where meteoOptions is the section in which the temperatureNC option
-            may be found.
-
-        Returns: Path to config file and work dir
+        Returns:
+            Path to config file and work dir
         """
         self._setup_work_dir()
         self._setup_config(cfg_file, input_dir, **kwargs)

--- a/ewatercycle/models/wflow.py
+++ b/ewatercycle/models/wflow.py
@@ -2,7 +2,7 @@ import shutil
 import time
 from os import PathLike
 from pathlib import Path
-from typing import Any, Iterable, Optional, Tuple
+from typing import Any, Iterable, Tuple
 
 import numpy as np
 import xarray as xr

--- a/ewatercycle/models/wflow.py
+++ b/ewatercycle/models/wflow.py
@@ -14,7 +14,7 @@ from grpc4bmi.bmi_client_docker import BmiClientDocker
 from grpc4bmi.bmi_client_singularity import BmiClientSingularity
 
 from ewatercycle import CFG
-from ewatercycle.forcing.wflow import WflowForcing
+from ewatercycle.forcing._wflow import WflowForcing
 from ewatercycle.models.abstract import AbstractModel
 from ewatercycle.parametersetdb.config import CaseConfigParser
 from ewatercycle.util import get_time

--- a/ewatercycle/util.py
+++ b/ewatercycle/util.py
@@ -1,10 +1,10 @@
+from datetime import datetime
 from pathlib import Path
-from typing import Any, Tuple, Dict
+from typing import Any, Dict, Tuple
 
 import fiona
 import numpy as np
 import xarray as xr
-from datetime import datetime
 from dateutil.parser import parse
 from esmvalcore.experimental.recipe_output import RecipeOutput
 from shapely import geometry
@@ -29,11 +29,14 @@ def var_to_xarray(model, variable):
 
     # Create xarray object
     da = xr.DataArray(data,
-                      coords = {'longitude': lon, 'latitude': lat, 'time': time},
-                      dims = ['latitude', 'longitude'],
-                      name = variable,
-                      attrs = {'units': model.get_var_units(variable)}
-                      )
+                      coords={
+                          'longitude': lon,
+                          'latitude': lat,
+                          'time': time
+                      },
+                      dims=['latitude', 'longitude'],
+                      name=variable,
+                      attrs={'units': model.get_var_units(variable)})
 
     # Masked invalid values on return array:
     return da.where(da != -999)
@@ -54,18 +57,19 @@ def lat_lon_to_closest_variable_indices(model, variable, lats, lons):
     if len(lats) == 1:
         idx = np.abs(latModel - lats).argmin()
         idy = np.abs(lonModel - lons).argmin()
-        output = idx+nx*idy
+        output = idx + nx * idy
     else:
-        output=[]
-        for [lat,lon] in [lats, lons]:
+        output = []
+        for [lat, lon] in [lats, lons]:
             idx = np.abs(latModel - lat).argmin()
             idy = np.abs(lonModel - lon).argmin()
-            output.append(idx+nx*idy)
+            output.append(idx + nx * idy)
 
     return np.array(output)
 
 
-def lat_lon_boundingbox_to_variable_indices(model, variable, latMin, latMax, lonMin, lonMax):
+def lat_lon_boundingbox_to_variable_indices(model, variable, latMin, latMax,
+                                            lonMin, lonMax):
     """Translate bounding boxes of lat, lon coordinates into BMI model
     indices, which are used to get and set variable values.
     """
@@ -75,13 +79,17 @@ def lat_lon_boundingbox_to_variable_indices(model, variable, latMin, latMax, lon
     lonModel = model.get_grid_y(model.get_var_grid(variable))
     nx = len(latModel)
 
-    idx = [i for i,v in enumerate(latModel) if ((v > latMin) and (v < latMax))]
-    idy = [i for i,v in enumerate(lonModel) if ((v > lonMin) and (v < lonMax))]
+    idx = [
+        i for i, v in enumerate(latModel) if ((v > latMin) and (v < latMax))
+    ]
+    idy = [
+        i for i, v in enumerate(lonModel) if ((v > lonMin) and (v < lonMax))
+    ]
 
     output = []
     for x in idx:
         for y in idy:
-            output.append(x + nx*y)
+            output.append(x + nx * y)
 
     return np.array(output)
 
@@ -112,9 +120,7 @@ def get_extents(shapefile: Any, pad=0) -> Dict[str, float]:
         Dict with `start_longitude`, `start_latitude`, `end_longitude`, `end_latitude`
     """
     shape = fiona.open(shapefile)
-    x0, y0, x1, y1 = [
-        geometry.shape(p["geometry"]).bounds for p in shape
-    ][0]
+    x0, y0, x1, y1 = [geometry.shape(p["geometry"]).bounds for p in shape][0]
     x0 = round((x0 - pad), 1)
     y0 = round((y0 - pad), 1)
     x1 = round((x1 + pad), 1)
@@ -127,7 +133,8 @@ def get_extents(shapefile: Any, pad=0) -> Dict[str, float]:
     }
 
 
-def data_files_from_recipe_output(recipe_output: RecipeOutput) -> Tuple[str, Dict[str, str]]:
+def data_files_from_recipe_output(
+        recipe_output: RecipeOutput) -> Tuple[str, Dict[str, str]]:
     """Get data files from a ESMVaLTool recipe output
 
     Expects first diagnostic task to produce files with single var each.
@@ -149,3 +156,17 @@ def data_files_from_recipe_output(recipe_output: RecipeOutput) -> Tuple[str, Dic
     # TODO simplify (recipe_output.location) when next esmvalcore release is made
     directory = str(data_files[0].filename.parent)
     return directory, forcing_files
+
+
+def parse_path(input_path: str, must_exist: bool = False) -> Path:
+    """Parse input string as pathlib.Path object."""
+    try:
+        parsed_path = Path(input_path).expanduser().resolve()
+    except Exception as e:
+        raise ValueError(f"Tried to parse input path {input_path}, "
+                         f"but failed with exception: {e}")
+
+    if must_exist and not parsed_path.exists():
+        raise ValueError(f"Got non-existent path {input_path}.")
+
+    return parsed_path

--- a/tests/forcing/test_default.py
+++ b/tests/forcing/test_default.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ewatercycle.forcing import generate, load_foreign, DefaultForcing, load
+from ewatercycle.forcing import generate, load_foreign
 
 
 def test_generate_unknown_model(sample_shape):

--- a/tests/forcing/test_lisflood.py
+++ b/tests/forcing/test_lisflood.py
@@ -11,6 +11,7 @@ from ewatercycle.forcing._lisflood import LisfloodForcing
 
 def test_plot():
     f = LisfloodForcing(
+        directory='.',
         start_time='1989-01-02T00:00:00Z',
         end_time='1999-01-02T00:00:00Z',
     )
@@ -22,16 +23,12 @@ def create_netcdf(var_name, filename):
     var = 15 + 8 * np.random.randn(2, 2, 3)
     lon = [[-99.83, -99.32], [-99.79, -99.23]]
     lat = [[42.25, 42.21], [42.63, 42.59]]
-    ds = xr.Dataset(
-        {
-            var_name: (["longitude", "latitude", "time"], var)
-        },
-        coords={
-            "lon": (["longitude", "latitude"], lon),
-            "lat": (["longitude", "latitude"], lat),
-            "time": pd.date_range("2014-09-06", periods=3),
-        }
-    )
+    ds = xr.Dataset({var_name: (["longitude", "latitude", "time"], var)},
+                    coords={
+                        "lon": (["longitude", "latitude"], lon),
+                        "lat": (["longitude", "latitude"], lat),
+                        "time": pd.date_range("2014-09-06", periods=3),
+                    })
     ds.to_netcdf(filename)
     return DataFile(filename)
 
@@ -74,136 +71,212 @@ class TestGenerateRegionFromShapeFile:
     @pytest.fixture
     def reference_recipe(self):
         return {
-            'datasets': [{'dataset': 'ERA5',
-                          'project': 'OBS6',
-                          'tier': 3,
-                          'type': 'reanaly',
-                          'version': 1}],
-            'diagnostics': {'diagnostic_daily': {'description': 'LISFLOOD input '
-                                                                'preprocessor for '
-                                                                'ERA-Interim and ERA5 '
-                                                                'data',
-                                                 'scripts': {'script': {'catchment': 'Rhine',
-                                                                        'script': 'hydrology/lisflood.py'}},
-                                                 'variables': {'pr': {'end_year': 1999,
-                                                                      'mip': 'day',
-                                                                      'preprocessor': 'daily_water',
-                                                                      'start_year': 1989},
-                                                               'rsds': {'end_year': 1999,
-                                                                        'mip': 'day',
-                                                                        'preprocessor': 'daily_radiation',
-                                                                        'start_year': 1989},
-                                                               'tas': {'end_year': 1999,
-                                                                       'mip': 'day',
-                                                                       'preprocessor': 'daily_temperature',
-                                                                       'start_year': 1989},
-                                                               'tasmax': {'end_year': 1999,
-                                                                          'mip': 'day',
-                                                                          'preprocessor': 'daily_temperature',
-                                                                          'start_year': 1989},
-                                                               'tasmin': {'end_year': 1999,
-                                                                          'mip': 'day',
-                                                                          'preprocessor': 'daily_temperature',
-                                                                          'start_year': 1989},
-                                                               'tdps': {'end_year': 1999,
-                                                                        'mip': 'Eday',
-                                                                        'preprocessor': 'daily_temperature',
-                                                                        'start_year': 1989},
-                                                               'uas': {'end_year': 1999,
-                                                                       'mip': 'day',
-                                                                       'preprocessor': 'daily_windspeed',
-                                                                       'start_year': 1989},
-                                                               'vas': {'end_year': 1999,
-                                                                       'mip': 'day',
-                                                                       'preprocessor': 'daily_windspeed',
-                                                                       'start_year': 1989}}}},
-            'documentation': {'authors': ['verhoeven_stefan',
-                                          'kalverla_peter',
-                                          'andela_bouwe'],
-                              'projects': ['ewatercycle'],
-                              'references': ['acknow_project']},
-            'preprocessors': {'daily_radiation': {'convert_units': {'units': 'J m-2 '
-                                                                             'day-1'},
-                                                  'custom_order': True,
-                                                  'extract_region': {'end_latitude': 52.2,
-                                                                     'end_longitude': 11.9,
-                                                                     'start_latitude': 46.3,
-                                                                     'start_longitude': 4.1},
-                                                  'extract_shape': {'crop': True,
-                                                                    'method': 'contains'},
-                                                  'regrid': {'lat_offset': True,
-                                                             'lon_offset': True,
-                                                             'scheme': 'linear',
-                                                             'target_grid': '0.1x0.1'}},
-                              'daily_temperature': {'convert_units': {'units': 'degC'},
-                                                    'custom_order': True,
-                                                    'extract_region': {'end_latitude': 52.2,
-                                                                       'end_longitude': 11.9,
-                                                                       'start_latitude': 46.3,
-                                                                       'start_longitude': 4.1},
-                                                    'extract_shape': {'crop': True,
-                                                                      'method': 'contains'},
-                                                    'regrid': {'lat_offset': True,
-                                                               'lon_offset': True,
-                                                               'scheme': 'linear',
-                                                               'target_grid': '0.1x0.1'}},
-                              'daily_water': {'convert_units': {'units': 'kg m-2 d-1'},
-                                              'custom_order': True,
-                                              'extract_region': {'end_latitude': 52.2,
-                                                                 'end_longitude': 11.9,
-                                                                 'start_latitude': 46.3,
-                                                                 'start_longitude': 4.1},
-                                              'extract_shape': {'crop': True,
-                                                                'method': 'contains'},
-                                              'regrid': {'lat_offset': True,
-                                                         'lon_offset': True,
-                                                         'scheme': 'linear',
-                                                         'target_grid': '0.1x0.1'}},
-                              'daily_windspeed': {'custom_order': True,
-                                                  'extract_region': {'end_latitude': 52.2,
-                                                                     'end_longitude': 11.9,
-                                                                     'start_latitude': 46.3,
-                                                                     'start_longitude': 4.1},
-                                                  'extract_shape': {'crop': True,
-                                                                    'method': 'contains'},
-                                                  'regrid': {'lat_offset': True,
-                                                             'lon_offset': True,
-                                                             'scheme': 'linear',
-                                                             'target_grid': '0.1x0.1'}},
-                              'general': {'custom_order': True,
-                                          'extract_region': {'end_latitude': 52.2,
-                                                             'end_longitude': 11.9,
-                                                             'start_latitude': 46.3,
-                                                             'start_longitude': 4.1},
-                                          'extract_shape': {'crop': True,
-                                                            'method': 'contains'},
-                                          'regrid': {'lat_offset': True,
-                                                     'lon_offset': True,
-                                                     'scheme': 'linear',
-                                                     'target_grid': '0.1x0.1'}
-                                          }
-                              }
+            'datasets': [{
+                'dataset': 'ERA5',
+                'project': 'OBS6',
+                'tier': 3,
+                'type': 'reanaly',
+                'version': 1
+            }],
+            'diagnostics': {
+                'diagnostic_daily': {
+                    'description':
+                    'LISFLOOD input '
+                    'preprocessor for '
+                    'ERA-Interim and ERA5 '
+                    'data',
+                    'scripts': {
+                        'script': {
+                            'catchment': 'Rhine',
+                            'script': 'hydrology/lisflood.py'
+                        }
+                    },
+                    'variables': {
+                        'pr': {
+                            'end_year': 1999,
+                            'mip': 'day',
+                            'preprocessor': 'daily_water',
+                            'start_year': 1989
+                        },
+                        'rsds': {
+                            'end_year': 1999,
+                            'mip': 'day',
+                            'preprocessor': 'daily_radiation',
+                            'start_year': 1989
+                        },
+                        'tas': {
+                            'end_year': 1999,
+                            'mip': 'day',
+                            'preprocessor': 'daily_temperature',
+                            'start_year': 1989
+                        },
+                        'tasmax': {
+                            'end_year': 1999,
+                            'mip': 'day',
+                            'preprocessor': 'daily_temperature',
+                            'start_year': 1989
+                        },
+                        'tasmin': {
+                            'end_year': 1999,
+                            'mip': 'day',
+                            'preprocessor': 'daily_temperature',
+                            'start_year': 1989
+                        },
+                        'tdps': {
+                            'end_year': 1999,
+                            'mip': 'Eday',
+                            'preprocessor': 'daily_temperature',
+                            'start_year': 1989
+                        },
+                        'uas': {
+                            'end_year': 1999,
+                            'mip': 'day',
+                            'preprocessor': 'daily_windspeed',
+                            'start_year': 1989
+                        },
+                        'vas': {
+                            'end_year': 1999,
+                            'mip': 'day',
+                            'preprocessor': 'daily_windspeed',
+                            'start_year': 1989
+                        }
+                    }
+                }
+            },
+            'documentation': {
+                'authors':
+                ['verhoeven_stefan', 'kalverla_peter', 'andela_bouwe'],
+                'projects': ['ewatercycle'],
+                'references': ['acknow_project']
+            },
+            'preprocessors': {
+                'daily_radiation': {
+                    'convert_units': {
+                        'units': 'J m-2 '
+                        'day-1'
+                    },
+                    'custom_order': True,
+                    'extract_region': {
+                        'end_latitude': 52.2,
+                        'end_longitude': 11.9,
+                        'start_latitude': 46.3,
+                        'start_longitude': 4.1
+                    },
+                    'extract_shape': {
+                        'crop': True,
+                        'method': 'contains'
+                    },
+                    'regrid': {
+                        'lat_offset': True,
+                        'lon_offset': True,
+                        'scheme': 'linear',
+                        'target_grid': '0.1x0.1'
+                    }
+                },
+                'daily_temperature': {
+                    'convert_units': {
+                        'units': 'degC'
+                    },
+                    'custom_order': True,
+                    'extract_region': {
+                        'end_latitude': 52.2,
+                        'end_longitude': 11.9,
+                        'start_latitude': 46.3,
+                        'start_longitude': 4.1
+                    },
+                    'extract_shape': {
+                        'crop': True,
+                        'method': 'contains'
+                    },
+                    'regrid': {
+                        'lat_offset': True,
+                        'lon_offset': True,
+                        'scheme': 'linear',
+                        'target_grid': '0.1x0.1'
+                    }
+                },
+                'daily_water': {
+                    'convert_units': {
+                        'units': 'kg m-2 d-1'
+                    },
+                    'custom_order': True,
+                    'extract_region': {
+                        'end_latitude': 52.2,
+                        'end_longitude': 11.9,
+                        'start_latitude': 46.3,
+                        'start_longitude': 4.1
+                    },
+                    'extract_shape': {
+                        'crop': True,
+                        'method': 'contains'
+                    },
+                    'regrid': {
+                        'lat_offset': True,
+                        'lon_offset': True,
+                        'scheme': 'linear',
+                        'target_grid': '0.1x0.1'
+                    }
+                },
+                'daily_windspeed': {
+                    'custom_order': True,
+                    'extract_region': {
+                        'end_latitude': 52.2,
+                        'end_longitude': 11.9,
+                        'start_latitude': 46.3,
+                        'start_longitude': 4.1
+                    },
+                    'extract_shape': {
+                        'crop': True,
+                        'method': 'contains'
+                    },
+                    'regrid': {
+                        'lat_offset': True,
+                        'lon_offset': True,
+                        'scheme': 'linear',
+                        'target_grid': '0.1x0.1'
+                    }
+                },
+                'general': {
+                    'custom_order': True,
+                    'extract_region': {
+                        'end_latitude': 52.2,
+                        'end_longitude': 11.9,
+                        'start_latitude': 46.3,
+                        'start_longitude': 4.1
+                    },
+                    'extract_shape': {
+                        'crop': True,
+                        'method': 'contains'
+                    },
+                    'regrid': {
+                        'lat_offset': True,
+                        'lon_offset': True,
+                        'scheme': 'linear',
+                        'target_grid': '0.1x0.1'
+                    }
+                }
+            }
         }
 
     def test_result(self, forcing, tmp_path):
-        expected = LisfloodForcing(
-            directory=str(tmp_path),
-            start_time='1989-01-02T00:00:00Z',
-            end_time='1999-01-02T00:00:00Z',
-            PrefixPrecipitation='lisflood_pr.nc',
-            PrefixTavg='lisflood_tas.nc',
-            PrefixE0='lisflood_e0.nc',
-            PrefixES0='lisflood_es0.nc',
-            PrefixET0='lisflood_et0.nc'
-        )
+        expected = LisfloodForcing(directory=str(tmp_path),
+                                   start_time='1989-01-02T00:00:00Z',
+                                   end_time='1999-01-02T00:00:00Z',
+                                   PrefixPrecipitation='lisflood_pr.nc',
+                                   PrefixTavg='lisflood_tas.nc',
+                                   PrefixE0='lisflood_e0.nc',
+                                   PrefixES0='lisflood_es0.nc',
+                                   PrefixET0='lisflood_et0.nc')
         assert forcing == expected
 
-    def test_recipe_configured(self, forcing, mock_recipe_run, reference_recipe, sample_shape):
+    def test_recipe_configured(self, forcing, mock_recipe_run,
+                               reference_recipe, sample_shape):
         actual = mock_recipe_run['data_during_run']
         # Remove long description and absolute path so assert is easier
         actual_desc = actual['documentation']['description']
         del actual['documentation']['description']
-        actual_shapefile = actual['preprocessors']['general']['extract_shape']['shapefile']
+        actual_shapefile = actual['preprocessors']['general']['extract_shape'][
+            'shapefile']
         # Will also del other occurrences of shapefile due to extract shape object being shared between preprocessors
         del actual['preprocessors']['general']['extract_shape']['shapefile']
 

--- a/tests/forcing/test_lisflood.py
+++ b/tests/forcing/test_lisflood.py
@@ -6,7 +6,7 @@ from esmvalcore.experimental.recipe_output import DataFile
 import xarray as xr
 
 from ewatercycle.forcing import generate, load
-from ewatercycle.forcing.lisflood import LisfloodForcing
+from ewatercycle.forcing._lisflood import LisfloodForcing
 
 
 def test_plot():

--- a/tests/forcing/test_marrmot.py
+++ b/tests/forcing/test_marrmot.py
@@ -10,8 +10,10 @@ from ewatercycle.forcing._marrmot import MarrmotForcing
 
 def test_plot():
     f = MarrmotForcing(
+        directory='.',
         start_time='1989-01-02T00:00:00Z',
         end_time='1999-01-02T00:00:00Z',
+        forcing_file='marrmot.mat',
     )
     with pytest.raises(NotImplementedError):
         f.plot()

--- a/tests/forcing/test_marrmot.py
+++ b/tests/forcing/test_marrmot.py
@@ -5,7 +5,7 @@ from esmvalcore.experimental import Recipe
 from esmvalcore.experimental.recipe_output import OutputFile
 
 from ewatercycle.forcing import generate, load, load_foreign
-from ewatercycle.forcing.marrmot import MarrmotForcing
+from ewatercycle.forcing._marrmot import MarrmotForcing
 
 
 def test_plot():

--- a/tests/forcing/test_pcrglobwb.py
+++ b/tests/forcing/test_pcrglobwb.py
@@ -6,7 +6,7 @@ from esmvalcore.experimental.recipe_output import DataFile
 import xarray as xr
 
 from ewatercycle.forcing import generate
-from ewatercycle.forcing.pcrglobwb import PCRGlobWBForcing
+from ewatercycle.forcing._pcrglobwb import PCRGlobWBForcing
 
 
 def create_netcdf(var_name, filename):

--- a/tests/forcing/test_wflow.py
+++ b/tests/forcing/test_wflow.py
@@ -5,7 +5,7 @@ from esmvalcore.experimental.recipe import Recipe
 from esmvalcore.experimental.recipe_output import DataFile
 
 from ewatercycle.forcing import generate, load
-from ewatercycle.forcing.wflow import WflowForcing
+from ewatercycle.forcing._wflow import WflowForcing
 
 
 @pytest.fixture

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,9 +1,8 @@
 from datetime import datetime, timezone
-from pathlib import Path
 
 import pytest
 
-from ewatercycle.util import get_time, parse_path
+from ewatercycle.util import get_time
 
 
 def test_get_time_with_utc():
@@ -24,22 +23,3 @@ def test_get_time_without_tz():
 
     assert 'not in UTC' in str(excinfo.value)
 
-
-def test_parse_path():
-    input_path = "~/nonexistent_file.txt"
-    parsed = parse_path(input_path)
-    expected = Path.home() / "nonexistent_file.txt"
-    assert parsed == expected
-
-
-def test_parse_path_must_exist():
-    input_path = "~/nonexistent_file.txt"
-    with pytest.raises(ValueError) as excinfo:
-        parse_path(input_path, must_exist=True)
-    assert "Got non-existent path" in str(excinfo.value)
-
-
-def test_parse_path_invalid():
-    with pytest.raises(ValueError) as excinfo:
-        parse_path(123)
-    assert "Tried to parse input path" in str(excinfo.value)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,8 +1,9 @@
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 
-from ewatercycle.util import get_time
+from ewatercycle.util import get_time, parse_path
 
 
 def test_get_time_with_utc():
@@ -23,3 +24,22 @@ def test_get_time_without_tz():
 
     assert 'not in UTC' in str(excinfo.value)
 
+
+def test_parse_path():
+    input_path = "~/nonexistent_file.txt"
+    parsed = parse_path(input_path)
+    expected = Path.home() / "nonexistent_file.txt"
+    assert parsed == expected
+
+
+def test_parse_path_must_exist():
+    input_path = "~/nonexistent_file.txt"
+    with pytest.raises(ValueError) as excinfo:
+        parse_path(input_path, must_exist=True)
+    assert "Got non-existent path" in str(excinfo.value)
+
+
+def test_parse_path_invalid():
+    with pytest.raises(ValueError) as excinfo:
+        parse_path(123)
+    assert "Tried to parse input path" in str(excinfo.value)


### PR DESCRIPTION
closes #97

Look like this (and similar for `load_foreign`):

![image](https://user-images.githubusercontent.com/17080502/120649896-8a966400-c47d-11eb-838d-269b17fe32b6.png)

Docstrings are added to `forcing._model.ModelForcing.__init__` and `forcing._model.ModelForcing.generate`, and should adhere to the following format:

```python
def __init__(self, ...):
    """
        model_specific_option1: documentation
        model_specific_option2: documentation
    """

@classmethod
def generate(cls, ...):
    """
        None: no model-specific options needed for this model
    """
```

Those docstrings will be collected from all models, combined into one listing, and added to the docstrings of the `forcing.generate` and `forcing.load_foreign` methods. To render nicely, one also needs to add the model to `docs/conf.py`:
```python
# Nice formatting of model-specific input parameters
napoleon_custom_sections = [
    ('hype', 'params_style'),
    ('lisflood', 'params_style'),
    ('marrmot', 'params_style'),
    ('pcrglobwb', 'params_style'),
    ('wflow', 'params_style'),
]
```
