### PR TITLE
Implement `set`- and `get_value_at coords`

### DIFF
--- a/ewatercycle/models/abstract.py
+++ b/ewatercycle/models/abstract.py
@@ -3,7 +3,6 @@ from os import PathLike
 from typing import Tuple, Iterable, Any
 
 import numpy as np
-import warnings
 import xarray as xr
 from basic_modeling_interface import Bmi
 

--- a/ewatercycle/models/abstract.py
+++ b/ewatercycle/models/abstract.py
@@ -123,6 +123,31 @@ class AbstractModel(metaclass=ABCMeta):
 
         """
 
+    def get_value_at_coord(self, name, lat: float, lon: float) -> np.ndarray:
+        """Get a copy of values of the given variable at lat/lon coordinates.
+
+        Args:
+            name: Name of variable
+            lat: Latitudinal value
+            lon: Longitudinal value
+
+        """
+        index = self.coord_to_index(lat,lon)
+        return self.get_value_at_indices(name, index)
+
+    def set_value_at_coord(self, name, lat: float, lon: float, value: np.ndarray) -> None:
+        """Specify a new value for a model variable at at lat/lon coordinates.
+
+        Args:
+            name: Name of variable
+            lat: Latitudinal value
+            lon: Longitudinal value
+            value: The new value for the specified variable.
+
+        """
+        index = self.coord_to_index(lat,lon)
+        return self.set_value_at_indices(name, index, value)
+
     @property
     @abstractmethod
     def parameters(self) -> Iterable[Tuple[str, Any]]:

--- a/ewatercycle/models/abstract.py
+++ b/ewatercycle/models/abstract.py
@@ -111,7 +111,7 @@ class AbstractModel(metaclass=ABCMeta):
         Args: index: The index into lat/lon values
 
         """
-        raise NotImplementedError("No generic indices_to_coords method available.")
+        raise NotImplementedError("Method to convert from indices to model coordinates not implemented for this model.")
 
     @abstractmethod
     def get_value_as_xarray(self, name: str) -> xr.DataArray:

--- a/ewatercycle/models/abstract.py
+++ b/ewatercycle/models/abstract.py
@@ -67,7 +67,7 @@ class AbstractModel(metaclass=ABCMeta):
             lon: Longitudinal value
 
         """
-        indices = self._coords_to_indices(name, lat, lon)
+        indices, _, _ = self._coords_to_indices(name, lat, lon)
         indices = np.array(indices)
         return self.bmi.get_value_at_indices(name, indices)
 
@@ -91,11 +91,11 @@ class AbstractModel(metaclass=ABCMeta):
             value: The new value for the specified variable.
 
         """
-        indices = self._coords_to_indices(name, lat, lon)
+        indices, _, _ = self._coords_to_indices(name, lat, lon)
         indices = np.array(indices)
         self.bmi.set_value_at_indices(name, indices, values)
 
-    def _coords_to_indices(self, name: str, lat: Iterable[float], lon: Iterable[float]) -> Iterable[int]:
+    def _coords_to_indices(self, name: str, lat: Iterable[float], lon: Iterable[float]) -> Tuple[Iterable[int], Iterable[float], Iterable[float]]:
         """Converts lat/lon values to index.
 
         Args:

--- a/ewatercycle/models/abstract.py
+++ b/ewatercycle/models/abstract.py
@@ -3,6 +3,7 @@ from os import PathLike
 from typing import Tuple, Iterable, Any
 
 import numpy as np
+import warnings
 import xarray as xr
 from basic_modeling_interface import Bmi
 
@@ -107,6 +108,9 @@ class AbstractModel(metaclass=ABCMeta):
             index: The index into the variable array
 
         """
+
+    def _conversion_feedback(self, coord_user, coord_converted):
+        warnings.warn(f"Your coordinate {coord_user} matches model coordinate {coord_converted}.")
 
     @abstractmethod
     def get_value_as_xarray(self, name: str) -> xr.DataArray:

--- a/ewatercycle/models/abstract.py
+++ b/ewatercycle/models/abstract.py
@@ -59,7 +59,7 @@ class AbstractModel(metaclass=ABCMeta):
         """
         return self.bmi.get_value(name)
 
-    def get_value_at_indices(self, name: str, indices: np.ndarray) -> np.ndarray:
+    def get_value_at_indices(self, name: str, indices: Iterable[int]) -> np.ndarray:
         """Get a copy of values of the given variable at particular indices.
 
         Args:
@@ -67,9 +67,10 @@ class AbstractModel(metaclass=ABCMeta):
             indices: The indices into the variable array
 
         """
+        indices = np.array(indices)
         return self.bmi.get_value_at_indices(name, indices)
 
-    def get_value_at_coords(self, name, lat: np.ndarray, lon: np.ndarray) -> np.ndarray:
+    def get_value_at_coords(self, name, lat: Iterable[float], lon: Iterable[float]) -> np.ndarray:
         """Get a copy of values of the given variable at lat/lon coordinates.
 
         Args:
@@ -91,7 +92,7 @@ class AbstractModel(metaclass=ABCMeta):
         """
         self.bmi.set_value(name, value)
 
-    def set_value_at_indices(self, name: str, indices: np.ndarray, value: np.ndarray) -> None:
+    def set_value_at_indices(self, name: str, indices: Iterable[int], value: np.ndarray) -> None:
         """Specify a new value for a model variable at particular indices.
 
         Args:
@@ -100,9 +101,10 @@ class AbstractModel(metaclass=ABCMeta):
             value: The new value for the specified variable.
 
         """
+        indices = np.array(indices)
         self.bmi.set_value_at_indices(name, indices, value)
 
-    def set_value_at_coords(self, name: str, lat: np.ndarray, lon: np.ndarray, values: np.ndarray) -> None:
+    def set_value_at_coords(self, name: str, lat: Iterable[float], lon: Iterable[float], values: np.ndarray) -> None:
         """Specify a new value for a model variable at at lat/lon coordinates.
 
         Args:
@@ -115,12 +117,11 @@ class AbstractModel(metaclass=ABCMeta):
         indices = self.coords_to_indices(name, lat, lon)
         self.set_value_at_indices(name, indices, values)
 
-    # TODO Fix this function
     def conversion_feedback(self, coord_user, coord_converted):
-        warnings.warn(f"Your coordinates {coord_user} matches model coordinates {coord_converted}.")
+        print(f"Your coordinates {coord_user} match these model coordinates {coord_converted}.")
 
     @abstractmethod
-    def coords_to_indices(self, name: str, lat: np.ndarray, lon: np.ndarray) -> np.ndarray:
+    def coords_to_indices(self, name: str, lat: Iterable[float], lon: Iterable[float]) -> Iterable[int]:
         """Converts lat/lon values to index.
 
         Args:
@@ -130,7 +131,7 @@ class AbstractModel(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def indices_to_coords(self, name: str, indices: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def indices_to_coords(self, name: str, indices: Iterable[int]) -> Tuple[Iterable[float], Iterable[float]]:
         """Convert index to lat/lon values.
 
         Args: index: The index into lat/lon values

--- a/ewatercycle/models/abstract.py
+++ b/ewatercycle/models/abstract.py
@@ -59,7 +59,7 @@ class AbstractModel(metaclass=ABCMeta):
         return self.bmi.get_value(name)
 
     def get_value_at_indices(self, name: str, indices: np.ndarray) -> np.ndarray:
-        """Get a copy of values of the given variable.
+        """Get a copy of values of the given variable at particular indices.
 
         Args:
             name: Name of variable
@@ -77,6 +77,17 @@ class AbstractModel(metaclass=ABCMeta):
 
         """
         self.bmi.set_value(name, value)
+
+    def set_value_at_indices(self, name: str, indices: np.ndarray, value: np.ndarray) -> None:
+        """Specify a new value for a model variable at particular indices.
+
+        Args:
+            name: Name of variable
+            indices: The indices into the variable array
+            value: The new value for the specified variable.
+
+        """
+        self.bmi.set_value_at_indices(name, indices, value)
 
     @abstractmethod
     def get_value_as_xarray(self, name: str) -> xr.DataArray:

--- a/ewatercycle/models/abstract.py
+++ b/ewatercycle/models/abstract.py
@@ -105,14 +105,6 @@ class AbstractModel(metaclass=ABCMeta):
         """
         raise NotImplementedError("Method to convert from coordinates to model indices not implemented for this model.")
 
-    def _indices_to_coords(self, name: str, indices: Iterable[int]) -> Tuple[Iterable[float], Iterable[float]]:
-        """Convert index to lat/lon values.
-
-        Args: index: The index into lat/lon values
-
-        """
-        raise NotImplementedError("Method to convert from indices to model coordinates not implemented for this model.")
-
     @abstractmethod
     def get_value_as_xarray(self, name: str) -> xr.DataArray:
         """Get a copy values of the given variable as xarray DataArray.

--- a/ewatercycle/models/abstract.py
+++ b/ewatercycle/models/abstract.py
@@ -126,12 +126,13 @@ class AbstractModel(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def index_to_coord(self, index: np.ndarray) -> tuple(float,float):
+    def index_to_coord(self, index: np.ndarray) -> Tuple[float,float]:
         """Convert index to lat/lon values.
 
         Args: index: The index into lat/lon values
 
         """
+
     @abstractmethod
     def conversion_feedback(self, coord_user, coord_converted):
         warnings.warn(f"Your coordinates {coord_user} matches model coordinates {coord_converted}.")

--- a/ewatercycle/models/abstract.py
+++ b/ewatercycle/models/abstract.py
@@ -103,7 +103,7 @@ class AbstractModel(metaclass=ABCMeta):
             lon: Longitudinal value
 
         """
-        raise NotImplementedError("No generic coords_to_indices method available.")
+        raise NotImplementedError("Method to convert from coordinates to model indices not implemented for this model.")
 
     def _indices_to_coords(self, name: str, indices: Iterable[int]) -> Tuple[Iterable[float], Iterable[float]]:
         """Convert index to lat/lon values.

--- a/ewatercycle/models/abstract.py
+++ b/ewatercycle/models/abstract.py
@@ -69,6 +69,18 @@ class AbstractModel(metaclass=ABCMeta):
         """
         return self.bmi.get_value_at_indices(name, indices)
 
+    def get_value_at_coord(self, name, lat: float, lon: float) -> np.ndarray:
+        """Get a copy of values of the given variable at lat/lon coordinates.
+
+        Args:
+            name: Name of variable
+            lat: Latitudinal value
+            lon: Longitudinal value
+
+        """
+        index = self.coord_to_index(lat,lon)
+        return self.get_value_at_indices(name, index)
+
     def set_value(self, name: str, value: np.ndarray) -> None:
         """Specify a new value for a model variable.
 
@@ -90,6 +102,19 @@ class AbstractModel(metaclass=ABCMeta):
         """
         self.bmi.set_value_at_indices(name, indices, value)
 
+    def set_value_at_coord(self, name, lat: float, lon: float, value: np.ndarray) -> None:
+        """Specify a new value for a model variable at at lat/lon coordinates.
+
+        Args:
+            name: Name of variable
+            lat: Latitudinal value
+            lon: Longitudinal value
+            value: The new value for the specified variable.
+
+        """
+        index = self.coord_to_index(lat,lon)
+        self.set_value_at_indices(name, index, value)
+
     @abstractmethod
     def coord_to_index(self, lat: float, lon: float) -> np.ndarray:
         """Converts lat/lon values to index.
@@ -104,13 +129,12 @@ class AbstractModel(metaclass=ABCMeta):
     def index_to_coord(self, index: np.ndarray) -> tuple(float,float):
         """Convert index to lat/lon values.
 
-        Args:
-            index: The index into the variable array
+        Args: index: The index into lat/lon values
 
         """
-
-    def _conversion_feedback(self, coord_user, coord_converted):
-        warnings.warn(f"Your coordinate {coord_user} matches model coordinate {coord_converted}.")
+    @abstractmethod
+    def conversion_feedback(self, coord_user, coord_converted):
+        warnings.warn(f"Your coordinates {coord_user} matches model coordinates {coord_converted}.")
 
     @abstractmethod
     def get_value_as_xarray(self, name: str) -> xr.DataArray:
@@ -122,31 +146,6 @@ class AbstractModel(metaclass=ABCMeta):
         Args: name: Name of the variable
 
         """
-
-    def get_value_at_coord(self, name, lat: float, lon: float) -> np.ndarray:
-        """Get a copy of values of the given variable at lat/lon coordinates.
-
-        Args:
-            name: Name of variable
-            lat: Latitudinal value
-            lon: Longitudinal value
-
-        """
-        index = self.coord_to_index(lat,lon)
-        return self.get_value_at_indices(name, index)
-
-    def set_value_at_coord(self, name, lat: float, lon: float, value: np.ndarray) -> None:
-        """Specify a new value for a model variable at at lat/lon coordinates.
-
-        Args:
-            name: Name of variable
-            lat: Latitudinal value
-            lon: Longitudinal value
-            value: The new value for the specified variable.
-
-        """
-        index = self.coord_to_index(lat,lon)
-        return self.set_value_at_indices(name, index, value)
 
     @property
     @abstractmethod

--- a/ewatercycle/models/abstract.py
+++ b/ewatercycle/models/abstract.py
@@ -90,6 +90,25 @@ class AbstractModel(metaclass=ABCMeta):
         self.bmi.set_value_at_indices(name, indices, value)
 
     @abstractmethod
+    def coord_to_index(self, lat: float, lon: float) -> np.ndarray:
+        """Converts lat/lon values to index.
+
+        Args:
+            lat: Latitudinal value
+            lon: Longitudinal value
+
+        """
+
+    @abstractmethod
+    def index_to_coord(self, index: np.ndarray) -> tuple(float,float):
+        """Convert index to lat/lon values.
+
+        Args:
+            index: The index into the variable array
+
+        """
+
+    @abstractmethod
     def get_value_as_xarray(self, name: str) -> xr.DataArray:
         """Get a copy values of the given variable as xarray DataArray.
 

--- a/ewatercycle/models/abstract.py
+++ b/ewatercycle/models/abstract.py
@@ -58,6 +58,16 @@ class AbstractModel(metaclass=ABCMeta):
         """
         return self.bmi.get_value(name)
 
+    def get_value_at_indices(self, name: str, indices: np.ndarray) -> np.ndarray:
+        """Get a copy of values of the given variable.
+
+        Args:
+            name: Name of variable
+            indices: The indices into the variable array
+
+        """
+        return self.bmi.get_value_at_indices(name, indices)
+
     def set_value(self, name: str, value: np.ndarray) -> None:
         """Specify a new value for a model variable.
 

--- a/ewatercycle/models/abstract.py
+++ b/ewatercycle/models/abstract.py
@@ -58,17 +58,6 @@ class AbstractModel(metaclass=ABCMeta):
         """
         return self.bmi.get_value(name)
 
-    def get_value_at_indices(self, name: str, indices: Iterable[int]) -> np.ndarray:
-        """Get a copy of values of the given variable at particular indices.
-
-        Args:
-            name: Name of variable
-            indices: The indices into the variable array
-
-        """
-        indices = np.array(indices)
-        return self.bmi.get_value_at_indices(name, indices)
-
     def get_value_at_coords(self, name, lat: Iterable[float], lon: Iterable[float]) -> np.ndarray:
         """Get a copy of values of the given variable at lat/lon coordinates.
 
@@ -78,8 +67,9 @@ class AbstractModel(metaclass=ABCMeta):
             lon: Longitudinal value
 
         """
-        indices = self.coords_to_indices(name, lat, lon)
-        return self.get_value_at_indices(name, indices)
+        indices = self._coords_to_indices(name, lat, lon)
+        indices = np.array(indices)
+        return self.bmi.get_value_at_indices(name, indices)
 
     def set_value(self, name: str, value: np.ndarray) -> None:
         """Specify a new value for a model variable.
@@ -91,18 +81,6 @@ class AbstractModel(metaclass=ABCMeta):
         """
         self.bmi.set_value(name, value)
 
-    def set_value_at_indices(self, name: str, indices: Iterable[int], value: np.ndarray) -> None:
-        """Specify a new value for a model variable at particular indices.
-
-        Args:
-            name: Name of variable
-            indices: The indices into the variable array
-            value: The new value for the specified variable.
-
-        """
-        indices = np.array(indices)
-        self.bmi.set_value_at_indices(name, indices, value)
-
     def set_value_at_coords(self, name: str, lat: Iterable[float], lon: Iterable[float], values: np.ndarray) -> None:
         """Specify a new value for a model variable at at lat/lon coordinates.
 
@@ -113,14 +91,11 @@ class AbstractModel(metaclass=ABCMeta):
             value: The new value for the specified variable.
 
         """
-        indices = self.coords_to_indices(name, lat, lon)
-        self.set_value_at_indices(name, indices, values)
+        indices = self._coords_to_indices(name, lat, lon)
+        indices = np.array(indices)
+        self.bmi.set_value_at_indices(name, indices, values)
 
-    def conversion_feedback(self, coord_user, coord_converted):
-        print(f"Your coordinates {coord_user} match these model coordinates {coord_converted}.")
-
-    @abstractmethod
-    def coords_to_indices(self, name: str, lat: Iterable[float], lon: Iterable[float]) -> Iterable[int]:
+    def _coords_to_indices(self, name: str, lat: Iterable[float], lon: Iterable[float]) -> Iterable[int]:
         """Converts lat/lon values to index.
 
         Args:
@@ -128,14 +103,15 @@ class AbstractModel(metaclass=ABCMeta):
             lon: Longitudinal value
 
         """
+        raise NotImplementedError("No generic coords_to_indices method available.")
 
-    @abstractmethod
-    def indices_to_coords(self, name: str, indices: Iterable[int]) -> Tuple[Iterable[float], Iterable[float]]:
+    def _indices_to_coords(self, name: str, indices: Iterable[int]) -> Tuple[Iterable[float], Iterable[float]]:
         """Convert index to lat/lon values.
 
         Args: index: The index into lat/lon values
 
         """
+        raise NotImplementedError("No generic indices_to_coords method available.")
 
     @abstractmethod
     def get_value_as_xarray(self, name: str) -> xr.DataArray:

--- a/ewatercycle/models/abstract.py
+++ b/ewatercycle/models/abstract.py
@@ -69,7 +69,7 @@ class AbstractModel(metaclass=ABCMeta):
         """
         return self.bmi.get_value_at_indices(name, indices)
 
-    def get_value_at_coord(self, name, lat: float, lon: float) -> np.ndarray:
+    def get_value_at_coords(self, name, lat: np.ndarray, lon: np.ndarray) -> np.ndarray:
         """Get a copy of values of the given variable at lat/lon coordinates.
 
         Args:
@@ -78,8 +78,8 @@ class AbstractModel(metaclass=ABCMeta):
             lon: Longitudinal value
 
         """
-        index = self.coord_to_index(lat,lon)
-        return self.get_value_at_indices(name, index)
+        indices = self.coords_to_indices(name, lat, lon)
+        return self.get_value_at_indices(name, indices)
 
     def set_value(self, name: str, value: np.ndarray) -> None:
         """Specify a new value for a model variable.
@@ -102,7 +102,7 @@ class AbstractModel(metaclass=ABCMeta):
         """
         self.bmi.set_value_at_indices(name, indices, value)
 
-    def set_value_at_coord(self, name, lat: float, lon: float, value: np.ndarray) -> None:
+    def set_value_at_coords(self, name: str, lat: np.ndarray, lon: np.ndarray, values: np.ndarray) -> None:
         """Specify a new value for a model variable at at lat/lon coordinates.
 
         Args:
@@ -112,11 +112,15 @@ class AbstractModel(metaclass=ABCMeta):
             value: The new value for the specified variable.
 
         """
-        index = self.coord_to_index(lat,lon)
-        self.set_value_at_indices(name, index, value)
+        indices = self.coords_to_indices(name, lat, lon)
+        self.set_value_at_indices(name, indices, values)
+
+    # TODO Fix this function
+    def conversion_feedback(self, coord_user, coord_converted):
+        warnings.warn(f"Your coordinates {coord_user} matches model coordinates {coord_converted}.")
 
     @abstractmethod
-    def coord_to_index(self, lat: float, lon: float) -> np.ndarray:
+    def coords_to_indices(self, name: str, lat: np.ndarray, lon: np.ndarray) -> np.ndarray:
         """Converts lat/lon values to index.
 
         Args:
@@ -126,16 +130,12 @@ class AbstractModel(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def index_to_coord(self, index: np.ndarray) -> Tuple[float,float]:
+    def indices_to_coords(self, name: str, indices: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
         """Convert index to lat/lon values.
 
         Args: index: The index into lat/lon values
 
         """
-
-    @abstractmethod
-    def conversion_feedback(self, coord_user, coord_converted):
-        warnings.warn(f"Your coordinates {coord_user} matches model coordinates {coord_converted}.")
 
     @abstractmethod
     def get_value_as_xarray(self, name: str) -> xr.DataArray:

--- a/ewatercycle/models/lisflood.py
+++ b/ewatercycle/models/lisflood.py
@@ -253,6 +253,7 @@ class Lisflood(AbstractModel):
 
         indices = []
         coord_converted = []
+        coord_user = []
         # in lisflood, x corresponds to lon, and y to lat.
         # this might not be the case for other models!
         for x, y in zip(lon, lat):
@@ -260,9 +261,9 @@ class Lisflood(AbstractModel):
             index = ((x_vectors - x) ** 2 + (y_vectors - y) ** 2).argmin()
             indices.append(index)
             idy, idx = np.unravel_index(index, shape)
-            coord_converted.append(np.around((x_model[idx], y_model[idy]), 2))
+            coord_converted.append((round(x_model[idx], 4), round(y_model[idy], 4))) # use 4 digits in round
+            coord_user.append((round(x, 4), round(y, 4)))
         # Provide feedback
-        coord_user = np.around(tuple(zip(lon, lat)), 2)
         print(f"Your coordinates {coord_user} match these model coordinates {coord_converted}.")
         return np.array(indices)
 

--- a/ewatercycle/models/lisflood.py
+++ b/ewatercycle/models/lisflood.py
@@ -255,15 +255,17 @@ class Lisflood(AbstractModel):
         # in lisflood, x corresponds to lon, and y to lat.
         # this might not be the case for other models!
         for x, y in zip(lon, lat):
-            distance, index = find_closest_point(x_model, y_model, x, y)
-            indices.append(index)
+            distance, index = find_closest_point(x_model, y_model, x, y)            
             idy, idx = np.unravel_index(index, shape)
-            lon_converted.append(round(x_model[idx], 4)) # use 4 digits in round
-            lat_converted.append(round(y_model[idy], 4)) # use 4 digits in round
+            
             # consider a threshold twice of the grid spacing
             # and convert spacing_model to km using this approximation: 1 degree ~ 111km
             if distance[idy, idx] > max(spacing_model) * 111 * 2:
                 raise ValueError("This point is outside of the model grid.")
+            
+            indices.append(index)
+            lon_converted.append(round(x_model[idx], 4)) # use 4 digits in round
+            lat_converted.append(round(y_model[idy], 4)) # use 4 digits in round
 
         return np.array(indices), np.array(lon_converted), np.array(lat_converted)
 

--- a/ewatercycle/models/lisflood.py
+++ b/ewatercycle/models/lisflood.py
@@ -257,7 +257,7 @@ class Lisflood(AbstractModel):
         # this might not be the case for other models!
         for x, y in zip(lon, lat):
             # here we use Euclidean distance, but it is not accurate as the coordinates are in lon/lat and degrees.
-            distance = (x_vectors - x) ** 2 + (y_vectors - y) ** 2
+            distance = ((x_vectors - x) ** 2 + (y_vectors - y) ** 2) ** (1/2)
             index = distance.argmin()
             indices.append(index)
             idy, idx = np.unravel_index(index, shape)

--- a/ewatercycle/models/lisflood.py
+++ b/ewatercycle/models/lisflood.py
@@ -14,7 +14,7 @@ from ewatercycle import CFG
 from ewatercycle.forcing.lisflood import LisfloodForcing
 from ewatercycle.models.abstract import AbstractModel
 from ewatercycle.parametersetdb.config import AbstractConfig
-from ewatercycle.util import get_time
+from ewatercycle.util import get_time, find_closest_point
 
 
 @dataclass
@@ -249,18 +249,13 @@ class Lisflood(AbstractModel):
         y_model = self.bmi.get_grid_y(grid_id)
         spacing_model = self.bmi.get_grid_spacing(grid_id)
 
-        # Create a grid from coordinates
-        x_vectors, y_vectors = np.meshgrid(x_model, y_model)
-
         indices = []
         lon_converted = []
         lat_converted = []
         # in lisflood, x corresponds to lon, and y to lat.
         # this might not be the case for other models!
         for x, y in zip(lon, lat):
-            # here we use Euclidean distance, but it is not accurate as the coordinates are in lon/lat and degrees.
-            distance = ((x_vectors - x) ** 2 + (y_vectors - y) ** 2) ** (1/2)
-            index = distance.argmin()
+            distance, index = find_closest_point(x_model, y_model, x, y)
             indices.append(index)
             idy, idx = np.unravel_index(index, shape)
             lon_converted.append(round(x_model[idx], 4)) # use 4 digits in round

--- a/ewatercycle/models/lisflood.py
+++ b/ewatercycle/models/lisflood.py
@@ -255,36 +255,19 @@ class Lisflood(AbstractModel):
         # in lisflood, x corresponds to lon, and y to lat.
         # this might not be the case for other models!
         for x, y in zip(lon, lat):
-            distance, index = find_closest_point(x_model, y_model, x, y)            
+            distance, index = find_closest_point(x_model, y_model, x, y)
             idy, idx = np.unravel_index(index, shape)
-            
+
             # consider a threshold twice of the grid spacing
             # and convert spacing_model to km using this approximation: 1 degree ~ 111km
             if distance[idy, idx] > max(spacing_model) * 111 * 2:
                 raise ValueError("This point is outside of the model grid.")
-            
+
             indices.append(index)
             lon_converted.append(round(x_model[idx], 4)) # use 4 digits in round
             lat_converted.append(round(y_model[idy], 4)) # use 4 digits in round
 
         return np.array(indices), np.array(lon_converted), np.array(lat_converted)
-
-    def _indices_to_coords(self, name: str, indices: Iterable[int]) -> Tuple[Iterable[float], Iterable[float]]:
-        """Convert index to lat/lon values."""
-        grid_id = self.bmi.get_var_grid(name)
-        shape = self.bmi.get_grid_shape(grid_id) # shape returns (len(y), len(x))
-        indices = np.array(indices)
-        idy, idx = np.unravel_index(indices, shape)
-        x_model = self.bmi.get_grid_x(grid_id)
-        y_model = self.bmi.get_grid_y(grid_id)
-        lon = []
-        lat = []
-        # in lisflood, x corresponds to lon, and y to lat.
-        # this might not be the case for other models!
-        for x, y in zip(idx, idy):
-            lon.append(x_model[x])
-            lat.append(y_model[y])
-        return np.array(lon), np.array(lat)
 
     @property
     def parameters(self) -> Iterable[Tuple[str, Any]]:

--- a/ewatercycle/models/lisflood.py
+++ b/ewatercycle/models/lisflood.py
@@ -266,8 +266,8 @@ class Lisflood(AbstractModel):
             lon_converted.append(round(x_model[idx], 4)) # use 4 digits in round
             lat_converted.append(round(y_model[idy], 4)) # use 4 digits in round
             # consider a threshold
-            if distance[idy, idx] > max(spacing_model):
-                print(f"Note: this point is outside of the model grid.")
+            if distance[idy, idx] > max(spacing_model) * 2:
+                raise ValueError("This point is outside of the model grid.")
 
         return np.array(indices), np.array(lon_converted), np.array(lat_converted)
 

--- a/ewatercycle/models/lisflood.py
+++ b/ewatercycle/models/lisflood.py
@@ -241,7 +241,7 @@ class Lisflood(AbstractModel):
 
         return da
 
-    def _coords_to_indices(self, name: str, lat: Iterable[float], lon: Iterable[float]) -> Iterable[int]:
+    def _coords_to_indices(self, name: str, lat: Iterable[float], lon: Iterable[float]) -> Tuple[Iterable[int], Iterable[float], Iterable[float]]:
         """Convert lat, lon coordinates into model indices."""
         grid_id = self.bmi.get_var_grid(name)
         shape = self.bmi.get_grid_shape(grid_id) # shape returns (len(y), len(x))
@@ -253,6 +253,8 @@ class Lisflood(AbstractModel):
         x_vectors, y_vectors = np.meshgrid(x_model, y_model)
 
         indices = []
+        lon_converted = []
+        lat_converted = []
         # in lisflood, x corresponds to lon, and y to lat.
         # this might not be the case for other models!
         for x, y in zip(lon, lat):
@@ -261,15 +263,13 @@ class Lisflood(AbstractModel):
             index = distance.argmin()
             indices.append(index)
             idy, idx = np.unravel_index(index, shape)
-            coord_converted = (round(x_model[idx], 4), round(y_model[idy], 4)) # use 4 digits in round
-            coord_user = (round(x, 4), round(y, 4))
-            # Provide feedback
-            print(f"Your coordinates {coord_user} are closest to these model coordinates {coord_converted}.")
+            lon_converted.append(round(x_model[idx], 4)) # use 4 digits in round
+            lat_converted.append(round(y_model[idy], 4)) # use 4 digits in round
             # consider a threshold
             if distance[idy, idx] > max(spacing_model):
                 print(f"Note: this point is outside of the model grid.")
 
-        return np.array(indices)
+        return np.array(indices), np.array(lon_converted), np.array(lat_converted)
 
     def _indices_to_coords(self, name: str, indices: Iterable[int]) -> Tuple[Iterable[float], Iterable[float]]:
         """Convert index to lat/lon values."""

--- a/ewatercycle/models/lisflood.py
+++ b/ewatercycle/models/lisflood.py
@@ -260,8 +260,9 @@ class Lisflood(AbstractModel):
             idy, idx = np.unravel_index(index, shape)
             lon_converted.append(round(x_model[idx], 4)) # use 4 digits in round
             lat_converted.append(round(y_model[idy], 4)) # use 4 digits in round
-            # consider a threshold
-            if distance[idy, idx] > max(spacing_model) * 2:
+            # consider a threshold twice of the grid spacing
+            # and convert spacing_model to km using this approximation: 1 degree ~ 111km
+            if distance[idy, idx] > max(spacing_model) * 111 * 2:
                 raise ValueError("This point is outside of the model grid.")
 
         return np.array(indices), np.array(lon_converted), np.array(lat_converted)

--- a/ewatercycle/util.py
+++ b/ewatercycle/util.py
@@ -86,18 +86,18 @@ def lat_lon_boundingbox_to_variable_indices(model, variable, lat_min, lat_max, l
     return np.array(output)
 
 
-def find_closest_point(lonitudes: Iterable[float], latitudes: Iterable[float], longitude: float, latitude: float) -> Tuple[np.ndarray, int]:
+def find_closest_point(grid_longitudes: Iterable[float], grid_latitudes: Iterable[float], point_longitude: float, point_latitude: float) -> Tuple[np.ndarray, int]:
     """Find closest grid cell to a point based on Geographical distances.
 
     It uses Spherical Earth projected to a plane formula:
     https://en.wikipedia.org/wiki/Geographical_distance
     """
     # Create a grid from coordinates
-    lon_vectors, lat_vectors = np.meshgrid(lonitudes, latitudes)
+    lon_vectors, lat_vectors = np.meshgrid(grid_longitudes, grid_latitudes)
 
-    dlon = np.radians(lon_vectors - longitude)
-    dlat = np.radians(lat_vectors - latitude)
-    latm = np.radians((lat_vectors + latitude) / 2)
+    dlon = np.radians(lon_vectors - point_longitude)
+    dlat = np.radians(lat_vectors - point_latitude)
+    latm = np.radians((lat_vectors + point_latitude) / 2)
 
     # approximate radius of earth in km
     radius = 6373.0

--- a/ewatercycle/util.py
+++ b/ewatercycle/util.py
@@ -86,7 +86,7 @@ def lat_lon_boundingbox_to_variable_indices(model, variable, lat_min, lat_max, l
     return np.array(output)
 
 
-def find_closest_point(lonitudes: Iterable[float], latitudes: Iterable[float], longitude: float, latitude: float) -> Tuple[ Iterable[float], int]:
+def find_closest_point(lonitudes: Iterable[float], latitudes: Iterable[float], longitude: float, latitude: float) -> Tuple[np.ndarray, int]:
     """Find closest grid cell to a point based on Geographical distances.
 
     It uses Spherical Earth projected to a plane formula:

--- a/examples/lisflood.ipynb
+++ b/examples/lisflood.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8ad24cbe",
+   "id": "98b6b9e6",
    "metadata": {},
    "source": [
     "![image](https://www.ewatercycle.org/assets/logo.png)"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "2e1304eb",
+   "id": "4f336cab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,10 +25,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "78d8a9d4",
+   "execution_count": 2,
+   "id": "373ad524",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/fakhereh/miniconda3/envs/ewatercycle/lib/python3.9/site-packages/esmvalcore/experimental/_warnings.py:18: UserWarning: \n",
+      "  Thank you for trying out the new ESMValCore API.\n",
+      "  Note that this API is experimental and may be subject to change.\n",
+      "  More info: https://github.com/ESMValGroup/ESMValCore/issues/498\n",
+      "/home/fakhereh/miniconda3/envs/ewatercycle/lib/python3.9/site-packages/esmvalcore/experimental/config/_config_validators.py:254: ESMValToolDeprecationWarning: `write_plots` will be removed in 2.4.0.\n",
+      "/home/fakhereh/miniconda3/envs/ewatercycle/lib/python3.9/site-packages/esmvalcore/experimental/config/_config_validators.py:255: ESMValToolDeprecationWarning: `write_netcdf` will be removed in 2.4.0.\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "from ewatercycle import CFG\n",
@@ -39,7 +52,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fafe549f",
+   "id": "63b3cc53",
    "metadata": {},
    "source": [
     "## Run lisflood class\n",
@@ -56,7 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "4c871063",
+   "id": "2b7fef27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +79,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "11aafcbc",
+   "id": "d227fd31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "d2686cb2",
+   "id": "868a912f",
    "metadata": {},
    "outputs": [
     {
@@ -101,7 +114,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "ec981ac5",
+   "id": "257e524d",
    "metadata": {},
    "outputs": [
     {
@@ -136,13 +149,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "1067b40f",
+   "id": "da10144a",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<ewatercycle.models.lisflood.Lisflood at 0x2abdf3b77220>"
+       "<ewatercycle.models.lisflood.Lisflood at 0x2ba9ef8bb610>"
       ]
      },
      "execution_count": 7,
@@ -159,7 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "29ab8953",
+   "id": "28414949",
    "metadata": {},
    "outputs": [
     {
@@ -189,14 +202,14 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "0526226d",
+   "id": "da11e63c",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Running /nfs/home2/fakhereh/temp/lisflood_run/ewatercycle-lisflood-grpc4bmi_20.10.sif singularity container on port 45819\n"
+      "Running /nfs/home2/fakhereh/temp/lisflood_run/ewatercycle-lisflood-grpc4bmi_20.10.sif singularity container on port 48597\n"
      ]
     }
    ],
@@ -208,15 +221,15 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "72b9d383",
+   "id": "6936d901",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/scratch/shared/ewatercycle/lisflood_20210618_115651/lisflood_setting.xml\n",
-      "/scratch/shared/ewatercycle/lisflood_20210618_115651\n"
+      "/scratch/shared/ewatercycle/lisflood_20210618_132037/lisflood_setting.xml\n",
+      "/scratch/shared/ewatercycle/lisflood_20210618_132037\n"
      ]
     },
     {
@@ -248,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "1a39c125",
+   "id": "87553315",
    "metadata": {},
    "outputs": [
     {
@@ -267,7 +280,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "11284019",
+   "id": "b96dc253",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,7 +291,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "caebef64",
+   "id": "996b02f0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,7 +302,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "d71fad2d",
+   "id": "53411e09",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,7 +313,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "d70caf6f",
+   "id": "8c646a0a",
    "metadata": {},
    "outputs": [
     {
@@ -321,7 +334,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "bee75662",
+   "id": "982a7184",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,7 +344,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "f350c0b7",
+   "id": "1d63e289",
    "metadata": {},
    "outputs": [
     {
@@ -701,13 +714,13 @@
        "  * latitude   (latitude) float64 89.95 89.85 89.75 ... -59.75 -59.85 -59.95\n",
        "    time       object 1990-01-03 00:00:00\n",
        "Attributes:\n",
-       "    units:    m^3/s</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'Discharge'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>latitude</span>: 1500</li><li><span class='xr-has-index'>longitude</span>: 3600</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-3d4476f3-9fc9-406f-8a5d-652ef129e9ae' class='xr-array-in' type='checkbox' checked><label for='section-3d4476f3-9fc9-406f-8a5d-652ef129e9ae' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>nan nan nan nan nan nan nan nan ... nan nan nan nan nan nan nan nan</span></div><div class='xr-array-data'><pre>array([[nan, nan, nan, ..., nan, nan, nan],\n",
+       "    units:    m^3/s</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'Discharge'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>latitude</span>: 1500</li><li><span class='xr-has-index'>longitude</span>: 3600</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-4b37baf1-6415-481c-a1b1-94987568aba6' class='xr-array-in' type='checkbox' checked><label for='section-4b37baf1-6415-481c-a1b1-94987568aba6' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>nan nan nan nan nan nan nan nan ... nan nan nan nan nan nan nan nan</span></div><div class='xr-array-data'><pre>array([[nan, nan, nan, ..., nan, nan, nan],\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
        "       ...,\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
-       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></div></li><li class='xr-section-item'><input id='section-aeed1461-f898-42f2-95c9-0ffe785db7e6' class='xr-section-summary-in' type='checkbox'  checked><label for='section-aeed1461-f898-42f2-95c9-0ffe785db7e6' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-179.9 -179.8 ... 179.8 179.9</div><input id='attrs-6a5475ba-a27e-4b1e-8557-dacddb11427c' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-6a5475ba-a27e-4b1e-8557-dacddb11427c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d0ea40da-54ed-4b8c-9c48-fdd93777623c' class='xr-var-data-in' type='checkbox'><label for='data-d0ea40da-54ed-4b8c-9c48-fdd93777623c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-179.95, -179.85, -179.75, ...,  179.75,  179.85,  179.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>89.95 89.85 89.75 ... -59.85 -59.95</div><input id='attrs-38d71132-8663-4510-bf34-ab416c23e85c' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-38d71132-8663-4510-bf34-ab416c23e85c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e85f7882-9793-4f80-b415-fdcf5c34f916' class='xr-var-data-in' type='checkbox'><label for='data-e85f7882-9793-4f80-b415-fdcf5c34f916' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([ 89.95,  89.85,  89.75, ..., -59.75, -59.85, -59.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>1990-01-03 00:00:00</div><input id='attrs-438430c5-2e69-473a-9dd9-6e20ec62abfd' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-438430c5-2e69-473a-9dd9-6e20ec62abfd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1497d998-faa6-4c4b-8ab3-dd31b7908487' class='xr-var-data-in' type='checkbox'><label for='data-1497d998-faa6-4c4b-8ab3-dd31b7908487' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(cftime.DatetimeGregorian(1990, 1, 3, 0, 0, 0, 0), dtype=object)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-c0acc963-817d-47c4-acfa-6d4dbc973d19' class='xr-section-summary-in' type='checkbox'  checked><label for='section-c0acc963-817d-47c4-acfa-6d4dbc973d19' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m^3/s</dd></dl></div></li></ul></div></div>"
+       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></div></li><li class='xr-section-item'><input id='section-ca8f9b26-1316-4887-89d1-b31dba871c14' class='xr-section-summary-in' type='checkbox'  checked><label for='section-ca8f9b26-1316-4887-89d1-b31dba871c14' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-179.9 -179.8 ... 179.8 179.9</div><input id='attrs-723cd84c-a661-47cd-af80-eadb0814a205' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-723cd84c-a661-47cd-af80-eadb0814a205' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-713efe45-4873-4fec-b59e-548f447507b3' class='xr-var-data-in' type='checkbox'><label for='data-713efe45-4873-4fec-b59e-548f447507b3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-179.95, -179.85, -179.75, ...,  179.75,  179.85,  179.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>89.95 89.85 89.75 ... -59.85 -59.95</div><input id='attrs-e6f8a835-391f-4e92-8a69-fa9bd4d5e676' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-e6f8a835-391f-4e92-8a69-fa9bd4d5e676' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5009fb22-b31b-4cf6-901a-e5463ca971aa' class='xr-var-data-in' type='checkbox'><label for='data-5009fb22-b31b-4cf6-901a-e5463ca971aa' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([ 89.95,  89.85,  89.75, ..., -59.75, -59.85, -59.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>1990-01-03 00:00:00</div><input id='attrs-089b663a-8bd3-4747-bc43-f4f646ee39d2' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-089b663a-8bd3-4747-bc43-f4f646ee39d2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b83581a8-ebc9-43f8-8b40-cf233cb1ef9c' class='xr-var-data-in' type='checkbox'><label for='data-b83581a8-ebc9-43f8-8b40-cf233cb1ef9c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(cftime.DatetimeGregorian(1990, 1, 3, 0, 0, 0, 0), dtype=object)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-91b6f50c-28a0-47f3-a89a-b261f8d03b8e' class='xr-section-summary-in' type='checkbox'  checked><label for='section-91b6f50c-28a0-47f3-a89a-b261f8d03b8e' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m^3/s</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'Discharge' (latitude: 1500, longitude: 3600)>\n",
@@ -738,13 +751,13 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "8324693d",
+   "id": "eaf39e02",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x2abdf5087760>"
+       "<matplotlib.collections.QuadMesh at 0x2ba9f0dd3640>"
       ]
      },
      "execution_count": 18,
@@ -774,14 +787,14 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "6e8cc5fb",
+   "id": "81fd413f",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Your coordinates [(-71.35, 42.64)] match these model coordinates [(-71.35, 42.65)].\n"
+      "Your coordinates (-71.35, 42.64) are closest to these model coordinates (-71.35, 42.65).\n"
      ]
     },
     {
@@ -803,7 +816,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "2c2b5063",
+   "id": "5cad848d",
    "metadata": {},
    "outputs": [
     {
@@ -824,15 +837,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "id": "8b0b973d",
+   "execution_count": 22,
+   "id": "4f446be0",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Your coordinates [(-71.35, 42.65), (5.6, 50.7)] match these model coordinates [(-71.35, 42.65), (5.65, 50.65)].\n"
+      "Your coordinates (-71.35, 42.65) are closest to these model coordinates (-71.35, 42.65).\n",
+      "Your coordinates (5.6, 50.7) are closest to these model coordinates (5.65, 50.65).\n"
      ]
     },
     {
@@ -841,7 +855,7 @@
        "array([1703886, 1416656])"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -853,8 +867,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "id": "9552268e",
+   "execution_count": 23,
+   "id": "2d6abd71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -865,7 +879,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "971aa1cd",
+   "id": "7cfd4ec0",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/examples/lisflood.ipynb
+++ b/examples/lisflood.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "2c3c4d2f",
+   "id": "29c0c279",
    "metadata": {},
    "source": [
     "![image](https://www.ewatercycle.org/assets/logo.png)"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "353e84c9",
+   "id": "c23f29f5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b56d961",
+   "id": "7f8dc3d0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0499038a",
+   "id": "7bdfac64",
    "metadata": {},
    "source": [
     "## Run lisflood class\n",
@@ -56,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "9601ff53",
+   "id": "10f0e2f3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "27423afd",
+   "id": "cfc46fa9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "1aa8cd99",
+   "id": "eb8687cb",
    "metadata": {},
    "outputs": [
     {
@@ -101,7 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "3c6f452c",
+   "id": "701c214c",
    "metadata": {},
    "outputs": [
     {
@@ -136,13 +136,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "e775be11",
+   "id": "f00edbdd",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<ewatercycle.models.lisflood.Lisflood at 0x2b61aaa350a0>"
+       "<ewatercycle.models.lisflood.Lisflood at 0x2b07d25893d0>"
       ]
      },
      "execution_count": 7,
@@ -159,7 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "c7b5daa7",
+   "id": "44035540",
    "metadata": {},
    "outputs": [
     {
@@ -189,14 +189,14 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "67caa62f",
+   "id": "d2f6b48a",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Running /nfs/home2/fakhereh/temp/lisflood_run/ewatercycle-lisflood-grpc4bmi_20.10.sif singularity container on port 46815\n"
+      "Running /nfs/home2/fakhereh/temp/lisflood_run/ewatercycle-lisflood-grpc4bmi_20.10.sif singularity container on port 48831\n"
      ]
     }
    ],
@@ -208,15 +208,15 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "079e7423",
+   "id": "32cc5e24",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/scratch/shared/ewatercycle/lisflood_20210602_111233/lisflood_setting.xml\n",
-      "/scratch/shared/ewatercycle/lisflood_20210602_111233\n"
+      "/scratch/shared/ewatercycle/lisflood_20210611_152348/lisflood_setting.xml\n",
+      "/scratch/shared/ewatercycle/lisflood_20210611_152348\n"
      ]
     },
     {
@@ -248,7 +248,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "7758a116",
+   "id": "39d9abcd",
    "metadata": {},
    "outputs": [
     {
@@ -267,7 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "617bca0e",
+   "id": "0703b323",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,7 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "22266595",
+   "id": "9b8f90c2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "4cbdc936",
+   "id": "61ebe22d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,7 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "9f57aed3",
+   "id": "cce90810",
    "metadata": {},
    "outputs": [
     {
@@ -321,7 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "25c0eedd",
+   "id": "96cd8994",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,7 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "b90747db",
+   "id": "e54a8b89",
    "metadata": {},
    "outputs": [
     {
@@ -701,13 +701,13 @@
        "  * latitude   (latitude) float64 89.95 89.85 89.75 ... -59.75 -59.85 -59.95\n",
        "    time       object 1990-01-03 00:00:00\n",
        "Attributes:\n",
-       "    units:    m^3/s</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'Discharge'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>latitude</span>: 1500</li><li><span class='xr-has-index'>longitude</span>: 3600</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-9f63be35-f4e4-4748-8526-49c3db0a1372' class='xr-array-in' type='checkbox' checked><label for='section-9f63be35-f4e4-4748-8526-49c3db0a1372' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>nan nan nan nan nan nan nan nan ... nan nan nan nan nan nan nan nan</span></div><div class='xr-array-data'><pre>array([[nan, nan, nan, ..., nan, nan, nan],\n",
+       "    units:    m^3/s</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'Discharge'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>latitude</span>: 1500</li><li><span class='xr-has-index'>longitude</span>: 3600</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-d84af2cc-e105-44f3-a063-e2dd2ef303a8' class='xr-array-in' type='checkbox' checked><label for='section-d84af2cc-e105-44f3-a063-e2dd2ef303a8' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>nan nan nan nan nan nan nan nan ... nan nan nan nan nan nan nan nan</span></div><div class='xr-array-data'><pre>array([[nan, nan, nan, ..., nan, nan, nan],\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
        "       ...,\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
-       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></div></li><li class='xr-section-item'><input id='section-67e42b0d-0a44-4255-973c-2a94997da576' class='xr-section-summary-in' type='checkbox'  checked><label for='section-67e42b0d-0a44-4255-973c-2a94997da576' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-179.9 -179.8 ... 179.8 179.9</div><input id='attrs-059a2f92-f19c-4555-a9fb-418b8ac09a81' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-059a2f92-f19c-4555-a9fb-418b8ac09a81' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-12a50738-aab3-420c-94aa-777978d4ad3c' class='xr-var-data-in' type='checkbox'><label for='data-12a50738-aab3-420c-94aa-777978d4ad3c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-179.95, -179.85, -179.75, ...,  179.75,  179.85,  179.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>89.95 89.85 89.75 ... -59.85 -59.95</div><input id='attrs-e8a7a921-ff43-4303-9571-c9f14440714e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-e8a7a921-ff43-4303-9571-c9f14440714e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-988025a3-2334-4eea-8bfa-0f98c4cc4389' class='xr-var-data-in' type='checkbox'><label for='data-988025a3-2334-4eea-8bfa-0f98c4cc4389' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([ 89.95,  89.85,  89.75, ..., -59.75, -59.85, -59.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>1990-01-03 00:00:00</div><input id='attrs-24e21598-b6e4-4cd0-a858-ffb63d97ca1d' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-24e21598-b6e4-4cd0-a858-ffb63d97ca1d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6a4c6a3f-b571-4696-a711-16fc2f93c6c9' class='xr-var-data-in' type='checkbox'><label for='data-6a4c6a3f-b571-4696-a711-16fc2f93c6c9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(cftime.DatetimeGregorian(1990, 1, 3, 0, 0, 0, 0), dtype=object)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-147616d8-6f70-497a-b16b-cf551c34901a' class='xr-section-summary-in' type='checkbox'  checked><label for='section-147616d8-6f70-497a-b16b-cf551c34901a' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m^3/s</dd></dl></div></li></ul></div></div>"
+       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></div></li><li class='xr-section-item'><input id='section-263d232f-80cf-41d8-9c85-7d421fdd5f62' class='xr-section-summary-in' type='checkbox'  checked><label for='section-263d232f-80cf-41d8-9c85-7d421fdd5f62' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-179.9 -179.8 ... 179.8 179.9</div><input id='attrs-b23fed85-9e50-487b-84f4-9928545f9d70' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-b23fed85-9e50-487b-84f4-9928545f9d70' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b55c0c31-539b-4670-a794-82cf9c4b9542' class='xr-var-data-in' type='checkbox'><label for='data-b55c0c31-539b-4670-a794-82cf9c4b9542' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-179.95, -179.85, -179.75, ...,  179.75,  179.85,  179.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>89.95 89.85 89.75 ... -59.85 -59.95</div><input id='attrs-5e1e8e67-7a58-4332-8f54-44820b5a32a3' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-5e1e8e67-7a58-4332-8f54-44820b5a32a3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-87f505ff-fe98-4c4d-8586-e1d32d8916a0' class='xr-var-data-in' type='checkbox'><label for='data-87f505ff-fe98-4c4d-8586-e1d32d8916a0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([ 89.95,  89.85,  89.75, ..., -59.75, -59.85, -59.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>1990-01-03 00:00:00</div><input id='attrs-7a372283-d1a8-4999-9c1a-1c53d25df150' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7a372283-d1a8-4999-9c1a-1c53d25df150' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-63088dfd-6987-4ccd-9756-a89225ee62f6' class='xr-var-data-in' type='checkbox'><label for='data-63088dfd-6987-4ccd-9756-a89225ee62f6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(cftime.DatetimeGregorian(1990, 1, 3, 0, 0, 0, 0), dtype=object)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-cb2cd084-20f8-4b0b-b644-2bd20a459d46' class='xr-section-summary-in' type='checkbox'  checked><label for='section-cb2cd084-20f8-4b0b-b644-2bd20a459d46' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m^3/s</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'Discharge' (latitude: 1500, longitude: 3600)>\n",
@@ -738,13 +738,13 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "327c6dbd",
+   "id": "44cc1878",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x2b61abf2d640>"
+       "<matplotlib.collections.QuadMesh at 0x2b07d3a95e50>"
       ]
      },
      "execution_count": 18,
@@ -774,21 +774,124 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "aba9fb98",
+   "id": "c0a01307",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([9.10970681])"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# get value at a single index\n",
+    "model.get_value_at_indices('Discharge', np.array([1703886]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "6823e0d7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 9.10970681, 81.58106518])"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# get values at multiple indices\n",
+    "model.get_value_at_indices('Discharge', np.array([1703886, 1413056]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "2e175d3a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([9.10970681])"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# get value at coordinates\n",
+    "discharge_at_coords = model.get_value_at_coords('Discharge', lat=np.array([42.65]), lon=np.array([-71.35]))\n",
+    "discharge_at_coords"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "39a334ef",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([-71.35]), array([42.65]))"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# indices to coords\n",
+    "model.indices_to_coords('Discharge', np.array([1703886]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "fc267ee7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([1703886])"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# coords to indices\n",
+    "model.coords_to_indices('Discharge',  lat=np.array([42.65]), lon=np.array([-71.35]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "cd557214",
    "metadata": {},
    "outputs": [],
    "source": [
     "# stop the model\n",
     "del model.bmi"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "eb0f4fd1",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/lisflood.ipynb
+++ b/examples/lisflood.ipynb
@@ -795,28 +795,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "id": "9514cc8c",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(array([-71.35,   5.65]), array([42.65, 50.75]))"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# indices to coords\n",
-    "model._indices_to_coords('Discharge', [1703886, 1413056])"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 21,
    "id": "a28d9a36",
    "metadata": {},

--- a/examples/lisflood.ipynb
+++ b/examples/lisflood.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d2ab91e3",
+   "id": "8ad24cbe",
    "metadata": {},
    "source": [
     "![image](https://www.ewatercycle.org/assets/logo.png)"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "66136335",
+   "id": "2e1304eb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2da966d5",
+   "id": "78d8a9d4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf5021f9",
+   "id": "fafe549f",
    "metadata": {},
    "source": [
     "## Run lisflood class\n",
@@ -56,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "34c294cf",
+   "id": "4c871063",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "21b0fe92",
+   "id": "11aafcbc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "99891d3f",
+   "id": "d2686cb2",
    "metadata": {},
    "outputs": [
     {
@@ -101,7 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "3deb6be7",
+   "id": "ec981ac5",
    "metadata": {},
    "outputs": [
     {
@@ -136,13 +136,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "93cab12d",
+   "id": "1067b40f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<ewatercycle.models.lisflood.Lisflood at 0x2ab1cb2e35e0>"
+       "<ewatercycle.models.lisflood.Lisflood at 0x2abdf3b77220>"
       ]
      },
      "execution_count": 7,
@@ -159,7 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "f2d73118",
+   "id": "29ab8953",
    "metadata": {},
    "outputs": [
     {
@@ -189,14 +189,14 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "26a7cd87",
+   "id": "0526226d",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Running /nfs/home2/fakhereh/temp/lisflood_run/ewatercycle-lisflood-grpc4bmi_20.10.sif singularity container on port 57382\n"
+      "Running /nfs/home2/fakhereh/temp/lisflood_run/ewatercycle-lisflood-grpc4bmi_20.10.sif singularity container on port 45819\n"
      ]
     }
    ],
@@ -208,15 +208,15 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "d4df348f",
+   "id": "72b9d383",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/scratch/shared/ewatercycle/lisflood_20210615_181328/lisflood_setting.xml\n",
-      "/scratch/shared/ewatercycle/lisflood_20210615_181328\n"
+      "/scratch/shared/ewatercycle/lisflood_20210618_115651/lisflood_setting.xml\n",
+      "/scratch/shared/ewatercycle/lisflood_20210618_115651\n"
      ]
     },
     {
@@ -248,7 +248,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "26323584",
+   "id": "1a39c125",
    "metadata": {},
    "outputs": [
     {
@@ -267,7 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "3e3e69f8",
+   "id": "11284019",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,7 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "aa1d0a21",
+   "id": "caebef64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "ef33b4b9",
+   "id": "d71fad2d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,7 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "5e35b5c5",
+   "id": "d70caf6f",
    "metadata": {},
    "outputs": [
     {
@@ -321,7 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "138bd3c0",
+   "id": "bee75662",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,7 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "f0979553",
+   "id": "f350c0b7",
    "metadata": {},
    "outputs": [
     {
@@ -701,13 +701,13 @@
        "  * latitude   (latitude) float64 89.95 89.85 89.75 ... -59.75 -59.85 -59.95\n",
        "    time       object 1990-01-03 00:00:00\n",
        "Attributes:\n",
-       "    units:    m^3/s</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'Discharge'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>latitude</span>: 1500</li><li><span class='xr-has-index'>longitude</span>: 3600</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-a6f34bf8-9ceb-4f1d-b014-ee60e7d0256a' class='xr-array-in' type='checkbox' checked><label for='section-a6f34bf8-9ceb-4f1d-b014-ee60e7d0256a' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>nan nan nan nan nan nan nan nan ... nan nan nan nan nan nan nan nan</span></div><div class='xr-array-data'><pre>array([[nan, nan, nan, ..., nan, nan, nan],\n",
+       "    units:    m^3/s</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'Discharge'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>latitude</span>: 1500</li><li><span class='xr-has-index'>longitude</span>: 3600</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-3d4476f3-9fc9-406f-8a5d-652ef129e9ae' class='xr-array-in' type='checkbox' checked><label for='section-3d4476f3-9fc9-406f-8a5d-652ef129e9ae' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>nan nan nan nan nan nan nan nan ... nan nan nan nan nan nan nan nan</span></div><div class='xr-array-data'><pre>array([[nan, nan, nan, ..., nan, nan, nan],\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
        "       ...,\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
-       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></div></li><li class='xr-section-item'><input id='section-65b9fe1b-ec1b-4685-a1c6-1e9ca37cc4e3' class='xr-section-summary-in' type='checkbox'  checked><label for='section-65b9fe1b-ec1b-4685-a1c6-1e9ca37cc4e3' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-179.9 -179.8 ... 179.8 179.9</div><input id='attrs-86c3ffa0-6e61-4ef1-ab69-0f8848b17e74' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-86c3ffa0-6e61-4ef1-ab69-0f8848b17e74' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2fa24237-d147-4c46-840e-d250f47b1b02' class='xr-var-data-in' type='checkbox'><label for='data-2fa24237-d147-4c46-840e-d250f47b1b02' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-179.95, -179.85, -179.75, ...,  179.75,  179.85,  179.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>89.95 89.85 89.75 ... -59.85 -59.95</div><input id='attrs-bf9f1c8c-10bc-47da-af15-f6015eab2cc1' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-bf9f1c8c-10bc-47da-af15-f6015eab2cc1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-64add7b1-aa3e-4488-babe-0a04cf6ba3b6' class='xr-var-data-in' type='checkbox'><label for='data-64add7b1-aa3e-4488-babe-0a04cf6ba3b6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([ 89.95,  89.85,  89.75, ..., -59.75, -59.85, -59.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>1990-01-03 00:00:00</div><input id='attrs-225e805d-ffb7-466a-953a-f843a0f20ce5' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-225e805d-ffb7-466a-953a-f843a0f20ce5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3144accc-30f6-4aef-a0b3-19bad4a1e614' class='xr-var-data-in' type='checkbox'><label for='data-3144accc-30f6-4aef-a0b3-19bad4a1e614' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(cftime.DatetimeGregorian(1990, 1, 3, 0, 0, 0, 0), dtype=object)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-1df7e48b-0b38-4c4a-9d90-3b3f83e47c76' class='xr-section-summary-in' type='checkbox'  checked><label for='section-1df7e48b-0b38-4c4a-9d90-3b3f83e47c76' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m^3/s</dd></dl></div></li></ul></div></div>"
+       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></div></li><li class='xr-section-item'><input id='section-aeed1461-f898-42f2-95c9-0ffe785db7e6' class='xr-section-summary-in' type='checkbox'  checked><label for='section-aeed1461-f898-42f2-95c9-0ffe785db7e6' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-179.9 -179.8 ... 179.8 179.9</div><input id='attrs-6a5475ba-a27e-4b1e-8557-dacddb11427c' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-6a5475ba-a27e-4b1e-8557-dacddb11427c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d0ea40da-54ed-4b8c-9c48-fdd93777623c' class='xr-var-data-in' type='checkbox'><label for='data-d0ea40da-54ed-4b8c-9c48-fdd93777623c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-179.95, -179.85, -179.75, ...,  179.75,  179.85,  179.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>89.95 89.85 89.75 ... -59.85 -59.95</div><input id='attrs-38d71132-8663-4510-bf34-ab416c23e85c' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-38d71132-8663-4510-bf34-ab416c23e85c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e85f7882-9793-4f80-b415-fdcf5c34f916' class='xr-var-data-in' type='checkbox'><label for='data-e85f7882-9793-4f80-b415-fdcf5c34f916' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([ 89.95,  89.85,  89.75, ..., -59.75, -59.85, -59.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>1990-01-03 00:00:00</div><input id='attrs-438430c5-2e69-473a-9dd9-6e20ec62abfd' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-438430c5-2e69-473a-9dd9-6e20ec62abfd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1497d998-faa6-4c4b-8ab3-dd31b7908487' class='xr-var-data-in' type='checkbox'><label for='data-1497d998-faa6-4c4b-8ab3-dd31b7908487' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(cftime.DatetimeGregorian(1990, 1, 3, 0, 0, 0, 0), dtype=object)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-c0acc963-817d-47c4-acfa-6d4dbc973d19' class='xr-section-summary-in' type='checkbox'  checked><label for='section-c0acc963-817d-47c4-acfa-6d4dbc973d19' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m^3/s</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'Discharge' (latitude: 1500, longitude: 3600)>\n",
@@ -738,13 +738,13 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "80f512d3",
+   "id": "8324693d",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x2ab1e07d4790>"
+       "<matplotlib.collections.QuadMesh at 0x2abdf5087760>"
       ]
      },
      "execution_count": 18,
@@ -774,9 +774,16 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "bba2de03",
+   "id": "6e8cc5fb",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Your coordinates [(-71.35, 42.64)] match these model coordinates [(-71.35, 42.65)].\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
@@ -789,66 +796,14 @@
     }
    ],
    "source": [
-    "# get value at a single index\n",
-    "model.get_value_at_indices('Discharge', [1703886])"
+    "# get value at coordinates\n",
+    "model.get_value_at_coords('Discharge', lon=[-71.35], lat=[42.64])"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "3572d662",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([ 9.10970681, 81.58106518])"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# get values at multiple indices\n",
-    "model.get_value_at_indices('Discharge', [1703886, 1413056])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "6f204fc7",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Your coordinates [[-71.35  42.65]] match these model coordinates [array([-71.35,  42.65])].\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "array([9.10970681])"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# get value at coordinates\n",
-    "discharge_at_coords = model.get_value_at_coords('Discharge', lon=[-71.35], lat=[42.65])\n",
-    "discharge_at_coords"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "a4d23415",
+   "id": "2c2b5063",
    "metadata": {},
    "outputs": [
     {
@@ -857,28 +812,27 @@
        "(array([-71.35,   5.65]), array([42.65, 50.75]))"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# indices to coords\n",
-    "model.indices_to_coords('Discharge', [1703886, 1413056])"
+    "model._indices_to_coords('Discharge', [1703886, 1413056])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "id": "cd848cbf",
+   "execution_count": 21,
+   "id": "8b0b973d",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Your coordinates [[-71.35  42.65]\n",
-      " [  5.6   50.7 ]] match these model coordinates [array([-71.35,  42.65]), array([ 5.65, 50.65])].\n"
+      "Your coordinates [(-71.35, 42.65), (5.6, 50.7)] match these model coordinates [(-71.35, 42.65), (5.65, 50.65)].\n"
      ]
     },
     {
@@ -887,20 +841,20 @@
        "array([1703886, 1416656])"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# coords to indices\n",
-    "model.coords_to_indices('Discharge',  lon=[-71.35, 5.6], lat=[42.65, 50.7])"
+    "model._coords_to_indices('Discharge',  lon=[-71.35, 5.6], lat=[42.65, 50.7])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "id": "598cb904",
+   "execution_count": 22,
+   "id": "9552268e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -911,7 +865,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "066d8eed",
+   "id": "971aa1cd",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/examples/lisflood.ipynb
+++ b/examples/lisflood.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "98b6b9e6",
+   "id": "52e2f7fe",
    "metadata": {},
    "source": [
     "![image](https://www.ewatercycle.org/assets/logo.png)"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "4f336cab",
+   "id": "df68dec9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,23 +25,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "373ad524",
+   "execution_count": null,
+   "id": "aa855a37",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/fakhereh/miniconda3/envs/ewatercycle/lib/python3.9/site-packages/esmvalcore/experimental/_warnings.py:18: UserWarning: \n",
-      "  Thank you for trying out the new ESMValCore API.\n",
-      "  Note that this API is experimental and may be subject to change.\n",
-      "  More info: https://github.com/ESMValGroup/ESMValCore/issues/498\n",
-      "/home/fakhereh/miniconda3/envs/ewatercycle/lib/python3.9/site-packages/esmvalcore/experimental/config/_config_validators.py:254: ESMValToolDeprecationWarning: `write_plots` will be removed in 2.4.0.\n",
-      "/home/fakhereh/miniconda3/envs/ewatercycle/lib/python3.9/site-packages/esmvalcore/experimental/config/_config_validators.py:255: ESMValToolDeprecationWarning: `write_netcdf` will be removed in 2.4.0.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "from ewatercycle import CFG\n",
@@ -52,7 +39,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63b3cc53",
+   "id": "10125d57",
    "metadata": {},
    "source": [
     "## Run lisflood class\n",
@@ -69,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "2b7fef27",
+   "id": "8ff5018d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "d227fd31",
+   "id": "08860d19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "868a912f",
+   "id": "ceb61a04",
    "metadata": {},
    "outputs": [
     {
@@ -114,7 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "257e524d",
+   "id": "c220553e",
    "metadata": {},
    "outputs": [
     {
@@ -149,13 +136,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "da10144a",
+   "id": "2717526a",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<ewatercycle.models.lisflood.Lisflood at 0x2ba9ef8bb610>"
+       "<ewatercycle.models.lisflood.Lisflood at 0x2b4b48470250>"
       ]
      },
      "execution_count": 7,
@@ -172,7 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "28414949",
+   "id": "3ade51be",
    "metadata": {},
    "outputs": [
     {
@@ -202,14 +189,14 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "da11e63c",
+   "id": "ec7d05f7",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Running /nfs/home2/fakhereh/temp/lisflood_run/ewatercycle-lisflood-grpc4bmi_20.10.sif singularity container on port 48597\n"
+      "Running /nfs/home2/fakhereh/temp/lisflood_run/ewatercycle-lisflood-grpc4bmi_20.10.sif singularity container on port 42559\n"
      ]
     }
    ],
@@ -221,15 +208,15 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "6936d901",
+   "id": "e2707fc1",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/scratch/shared/ewatercycle/lisflood_20210618_132037/lisflood_setting.xml\n",
-      "/scratch/shared/ewatercycle/lisflood_20210618_132037\n"
+      "/scratch/shared/ewatercycle/lisflood_20210621_164834/lisflood_setting.xml\n",
+      "/scratch/shared/ewatercycle/lisflood_20210621_164834\n"
      ]
     },
     {
@@ -261,7 +248,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "87553315",
+   "id": "ebe5fdac",
    "metadata": {},
    "outputs": [
     {
@@ -280,7 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "b96dc253",
+   "id": "0ae3f0da",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,7 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "996b02f0",
+   "id": "4fb130e6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -302,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "53411e09",
+   "id": "ed424c51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,7 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "8c646a0a",
+   "id": "97fdceaa",
    "metadata": {},
    "outputs": [
     {
@@ -334,7 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "982a7184",
+   "id": "a08e63d8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,7 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "1d63e289",
+   "id": "d159b951",
    "metadata": {},
    "outputs": [
     {
@@ -714,13 +701,13 @@
        "  * latitude   (latitude) float64 89.95 89.85 89.75 ... -59.75 -59.85 -59.95\n",
        "    time       object 1990-01-03 00:00:00\n",
        "Attributes:\n",
-       "    units:    m^3/s</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'Discharge'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>latitude</span>: 1500</li><li><span class='xr-has-index'>longitude</span>: 3600</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-4b37baf1-6415-481c-a1b1-94987568aba6' class='xr-array-in' type='checkbox' checked><label for='section-4b37baf1-6415-481c-a1b1-94987568aba6' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>nan nan nan nan nan nan nan nan ... nan nan nan nan nan nan nan nan</span></div><div class='xr-array-data'><pre>array([[nan, nan, nan, ..., nan, nan, nan],\n",
+       "    units:    m^3/s</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'Discharge'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>latitude</span>: 1500</li><li><span class='xr-has-index'>longitude</span>: 3600</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-10710cc1-1b8f-45c8-b6c0-591f03514933' class='xr-array-in' type='checkbox' checked><label for='section-10710cc1-1b8f-45c8-b6c0-591f03514933' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>nan nan nan nan nan nan nan nan ... nan nan nan nan nan nan nan nan</span></div><div class='xr-array-data'><pre>array([[nan, nan, nan, ..., nan, nan, nan],\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
        "       ...,\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
-       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></div></li><li class='xr-section-item'><input id='section-ca8f9b26-1316-4887-89d1-b31dba871c14' class='xr-section-summary-in' type='checkbox'  checked><label for='section-ca8f9b26-1316-4887-89d1-b31dba871c14' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-179.9 -179.8 ... 179.8 179.9</div><input id='attrs-723cd84c-a661-47cd-af80-eadb0814a205' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-723cd84c-a661-47cd-af80-eadb0814a205' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-713efe45-4873-4fec-b59e-548f447507b3' class='xr-var-data-in' type='checkbox'><label for='data-713efe45-4873-4fec-b59e-548f447507b3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-179.95, -179.85, -179.75, ...,  179.75,  179.85,  179.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>89.95 89.85 89.75 ... -59.85 -59.95</div><input id='attrs-e6f8a835-391f-4e92-8a69-fa9bd4d5e676' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-e6f8a835-391f-4e92-8a69-fa9bd4d5e676' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5009fb22-b31b-4cf6-901a-e5463ca971aa' class='xr-var-data-in' type='checkbox'><label for='data-5009fb22-b31b-4cf6-901a-e5463ca971aa' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([ 89.95,  89.85,  89.75, ..., -59.75, -59.85, -59.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>1990-01-03 00:00:00</div><input id='attrs-089b663a-8bd3-4747-bc43-f4f646ee39d2' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-089b663a-8bd3-4747-bc43-f4f646ee39d2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b83581a8-ebc9-43f8-8b40-cf233cb1ef9c' class='xr-var-data-in' type='checkbox'><label for='data-b83581a8-ebc9-43f8-8b40-cf233cb1ef9c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(cftime.DatetimeGregorian(1990, 1, 3, 0, 0, 0, 0), dtype=object)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-91b6f50c-28a0-47f3-a89a-b261f8d03b8e' class='xr-section-summary-in' type='checkbox'  checked><label for='section-91b6f50c-28a0-47f3-a89a-b261f8d03b8e' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m^3/s</dd></dl></div></li></ul></div></div>"
+       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></div></li><li class='xr-section-item'><input id='section-e001452b-12fa-4c04-8670-df2ebc7540a1' class='xr-section-summary-in' type='checkbox'  checked><label for='section-e001452b-12fa-4c04-8670-df2ebc7540a1' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-179.9 -179.8 ... 179.8 179.9</div><input id='attrs-96a33734-845d-4f87-af7f-e3d7a038ef37' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-96a33734-845d-4f87-af7f-e3d7a038ef37' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-04adeab5-63fd-4547-a361-2f40106a0cfa' class='xr-var-data-in' type='checkbox'><label for='data-04adeab5-63fd-4547-a361-2f40106a0cfa' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-179.95, -179.85, -179.75, ...,  179.75,  179.85,  179.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>89.95 89.85 89.75 ... -59.85 -59.95</div><input id='attrs-3d974e5e-9f41-4c97-acc1-b4987409c690' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-3d974e5e-9f41-4c97-acc1-b4987409c690' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-008a7697-0b5b-486c-9b12-eb848e3f377f' class='xr-var-data-in' type='checkbox'><label for='data-008a7697-0b5b-486c-9b12-eb848e3f377f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([ 89.95,  89.85,  89.75, ..., -59.75, -59.85, -59.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>1990-01-03 00:00:00</div><input id='attrs-4b6f5d3c-a63c-4afe-8873-e5a3d868d1d3' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-4b6f5d3c-a63c-4afe-8873-e5a3d868d1d3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-314da915-ce97-493f-b079-70f066e6f26c' class='xr-var-data-in' type='checkbox'><label for='data-314da915-ce97-493f-b079-70f066e6f26c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(cftime.DatetimeGregorian(1990, 1, 3, 0, 0, 0, 0), dtype=object)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-99e08af7-f5f1-4a39-8441-cbfcc2784e1e' class='xr-section-summary-in' type='checkbox'  checked><label for='section-99e08af7-f5f1-4a39-8441-cbfcc2784e1e' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m^3/s</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'Discharge' (latitude: 1500, longitude: 3600)>\n",
@@ -751,13 +738,13 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "eaf39e02",
+   "id": "7d33c370",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x2ba9f0dd3640>"
+       "<matplotlib.collections.QuadMesh at 0x2b4b6b33cac0>"
       ]
      },
      "execution_count": 18,
@@ -787,16 +774,9 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "81fd413f",
+   "id": "92b884c5",
    "metadata": {},
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Your coordinates (-71.35, 42.64) are closest to these model coordinates (-71.35, 42.65).\n"
-     ]
-    },
     {
      "data": {
       "text/plain": [
@@ -816,7 +796,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "5cad848d",
+   "id": "9514cc8c",
    "metadata": {},
    "outputs": [
     {
@@ -837,25 +817,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "id": "4f446be0",
+   "execution_count": 21,
+   "id": "a28d9a36",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Your coordinates (-71.35, 42.65) are closest to these model coordinates (-71.35, 42.65).\n",
-      "Your coordinates (5.6, 50.7) are closest to these model coordinates (5.65, 50.65).\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "array([1703886, 1416656])"
+       "(array([1703886, 1413056]), array([-71.35,   5.65]), array([42.65, 50.75]))"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -867,8 +839,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "id": "2d6abd71",
+   "execution_count": 22,
+   "id": "9855918a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -879,7 +851,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7cfd4ec0",
+   "id": "675b6b06",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/examples/lisflood.ipynb
+++ b/examples/lisflood.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "29c0c279",
+   "id": "d2ab91e3",
    "metadata": {},
    "source": [
     "![image](https://www.ewatercycle.org/assets/logo.png)"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "c23f29f5",
+   "id": "66136335",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f8dc3d0",
+   "id": "2da966d5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bdfac64",
+   "id": "bf5021f9",
    "metadata": {},
    "source": [
     "## Run lisflood class\n",
@@ -56,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "10f0e2f3",
+   "id": "34c294cf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "cfc46fa9",
+   "id": "21b0fe92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "eb8687cb",
+   "id": "99891d3f",
    "metadata": {},
    "outputs": [
     {
@@ -101,7 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "701c214c",
+   "id": "3deb6be7",
    "metadata": {},
    "outputs": [
     {
@@ -136,13 +136,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "f00edbdd",
+   "id": "93cab12d",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<ewatercycle.models.lisflood.Lisflood at 0x2b07d25893d0>"
+       "<ewatercycle.models.lisflood.Lisflood at 0x2ab1cb2e35e0>"
       ]
      },
      "execution_count": 7,
@@ -159,7 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "44035540",
+   "id": "f2d73118",
    "metadata": {},
    "outputs": [
     {
@@ -189,14 +189,14 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "d2f6b48a",
+   "id": "26a7cd87",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Running /nfs/home2/fakhereh/temp/lisflood_run/ewatercycle-lisflood-grpc4bmi_20.10.sif singularity container on port 48831\n"
+      "Running /nfs/home2/fakhereh/temp/lisflood_run/ewatercycle-lisflood-grpc4bmi_20.10.sif singularity container on port 57382\n"
      ]
     }
    ],
@@ -208,15 +208,15 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "32cc5e24",
+   "id": "d4df348f",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/scratch/shared/ewatercycle/lisflood_20210611_152348/lisflood_setting.xml\n",
-      "/scratch/shared/ewatercycle/lisflood_20210611_152348\n"
+      "/scratch/shared/ewatercycle/lisflood_20210615_181328/lisflood_setting.xml\n",
+      "/scratch/shared/ewatercycle/lisflood_20210615_181328\n"
      ]
     },
     {
@@ -248,7 +248,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "39d9abcd",
+   "id": "26323584",
    "metadata": {},
    "outputs": [
     {
@@ -267,7 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "0703b323",
+   "id": "3e3e69f8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,7 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "9b8f90c2",
+   "id": "aa1d0a21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "61ebe22d",
+   "id": "ef33b4b9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,7 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "cce90810",
+   "id": "5e35b5c5",
    "metadata": {},
    "outputs": [
     {
@@ -321,7 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "96cd8994",
+   "id": "138bd3c0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,7 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "e54a8b89",
+   "id": "f0979553",
    "metadata": {},
    "outputs": [
     {
@@ -701,13 +701,13 @@
        "  * latitude   (latitude) float64 89.95 89.85 89.75 ... -59.75 -59.85 -59.95\n",
        "    time       object 1990-01-03 00:00:00\n",
        "Attributes:\n",
-       "    units:    m^3/s</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'Discharge'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>latitude</span>: 1500</li><li><span class='xr-has-index'>longitude</span>: 3600</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-d84af2cc-e105-44f3-a063-e2dd2ef303a8' class='xr-array-in' type='checkbox' checked><label for='section-d84af2cc-e105-44f3-a063-e2dd2ef303a8' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>nan nan nan nan nan nan nan nan ... nan nan nan nan nan nan nan nan</span></div><div class='xr-array-data'><pre>array([[nan, nan, nan, ..., nan, nan, nan],\n",
+       "    units:    m^3/s</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'Discharge'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>latitude</span>: 1500</li><li><span class='xr-has-index'>longitude</span>: 3600</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-a6f34bf8-9ceb-4f1d-b014-ee60e7d0256a' class='xr-array-in' type='checkbox' checked><label for='section-a6f34bf8-9ceb-4f1d-b014-ee60e7d0256a' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>nan nan nan nan nan nan nan nan ... nan nan nan nan nan nan nan nan</span></div><div class='xr-array-data'><pre>array([[nan, nan, nan, ..., nan, nan, nan],\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
        "       ...,\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
-       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></div></li><li class='xr-section-item'><input id='section-263d232f-80cf-41d8-9c85-7d421fdd5f62' class='xr-section-summary-in' type='checkbox'  checked><label for='section-263d232f-80cf-41d8-9c85-7d421fdd5f62' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-179.9 -179.8 ... 179.8 179.9</div><input id='attrs-b23fed85-9e50-487b-84f4-9928545f9d70' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-b23fed85-9e50-487b-84f4-9928545f9d70' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b55c0c31-539b-4670-a794-82cf9c4b9542' class='xr-var-data-in' type='checkbox'><label for='data-b55c0c31-539b-4670-a794-82cf9c4b9542' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-179.95, -179.85, -179.75, ...,  179.75,  179.85,  179.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>89.95 89.85 89.75 ... -59.85 -59.95</div><input id='attrs-5e1e8e67-7a58-4332-8f54-44820b5a32a3' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-5e1e8e67-7a58-4332-8f54-44820b5a32a3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-87f505ff-fe98-4c4d-8586-e1d32d8916a0' class='xr-var-data-in' type='checkbox'><label for='data-87f505ff-fe98-4c4d-8586-e1d32d8916a0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([ 89.95,  89.85,  89.75, ..., -59.75, -59.85, -59.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>1990-01-03 00:00:00</div><input id='attrs-7a372283-d1a8-4999-9c1a-1c53d25df150' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7a372283-d1a8-4999-9c1a-1c53d25df150' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-63088dfd-6987-4ccd-9756-a89225ee62f6' class='xr-var-data-in' type='checkbox'><label for='data-63088dfd-6987-4ccd-9756-a89225ee62f6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(cftime.DatetimeGregorian(1990, 1, 3, 0, 0, 0, 0), dtype=object)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-cb2cd084-20f8-4b0b-b644-2bd20a459d46' class='xr-section-summary-in' type='checkbox'  checked><label for='section-cb2cd084-20f8-4b0b-b644-2bd20a459d46' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m^3/s</dd></dl></div></li></ul></div></div>"
+       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></div></li><li class='xr-section-item'><input id='section-65b9fe1b-ec1b-4685-a1c6-1e9ca37cc4e3' class='xr-section-summary-in' type='checkbox'  checked><label for='section-65b9fe1b-ec1b-4685-a1c6-1e9ca37cc4e3' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-179.9 -179.8 ... 179.8 179.9</div><input id='attrs-86c3ffa0-6e61-4ef1-ab69-0f8848b17e74' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-86c3ffa0-6e61-4ef1-ab69-0f8848b17e74' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2fa24237-d147-4c46-840e-d250f47b1b02' class='xr-var-data-in' type='checkbox'><label for='data-2fa24237-d147-4c46-840e-d250f47b1b02' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-179.95, -179.85, -179.75, ...,  179.75,  179.85,  179.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>89.95 89.85 89.75 ... -59.85 -59.95</div><input id='attrs-bf9f1c8c-10bc-47da-af15-f6015eab2cc1' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-bf9f1c8c-10bc-47da-af15-f6015eab2cc1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-64add7b1-aa3e-4488-babe-0a04cf6ba3b6' class='xr-var-data-in' type='checkbox'><label for='data-64add7b1-aa3e-4488-babe-0a04cf6ba3b6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([ 89.95,  89.85,  89.75, ..., -59.75, -59.85, -59.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>time</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>1990-01-03 00:00:00</div><input id='attrs-225e805d-ffb7-466a-953a-f843a0f20ce5' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-225e805d-ffb7-466a-953a-f843a0f20ce5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3144accc-30f6-4aef-a0b3-19bad4a1e614' class='xr-var-data-in' type='checkbox'><label for='data-3144accc-30f6-4aef-a0b3-19bad4a1e614' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(cftime.DatetimeGregorian(1990, 1, 3, 0, 0, 0, 0), dtype=object)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-1df7e48b-0b38-4c4a-9d90-3b3f83e47c76' class='xr-section-summary-in' type='checkbox'  checked><label for='section-1df7e48b-0b38-4c4a-9d90-3b3f83e47c76' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>m^3/s</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'Discharge' (latitude: 1500, longitude: 3600)>\n",
@@ -738,13 +738,13 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "44cc1878",
+   "id": "80f512d3",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x2b07d3a95e50>"
+       "<matplotlib.collections.QuadMesh at 0x2ab1e07d4790>"
       ]
      },
      "execution_count": 18,
@@ -774,7 +774,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "c0a01307",
+   "id": "bba2de03",
    "metadata": {},
    "outputs": [
     {
@@ -790,13 +790,13 @@
    ],
    "source": [
     "# get value at a single index\n",
-    "model.get_value_at_indices('Discharge', np.array([1703886]))"
+    "model.get_value_at_indices('Discharge', [1703886])"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "6823e0d7",
+   "id": "3572d662",
    "metadata": {},
    "outputs": [
     {
@@ -812,86 +812,109 @@
    ],
    "source": [
     "# get values at multiple indices\n",
-    "model.get_value_at_indices('Discharge', np.array([1703886, 1413056]))"
+    "model.get_value_at_indices('Discharge', [1703886, 1413056])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
-   "id": "2e175d3a",
+   "execution_count": 21,
+   "id": "6f204fc7",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Your coordinates [[-71.35  42.65]] match these model coordinates [array([-71.35,  42.65])].\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "array([9.10970681])"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# get value at coordinates\n",
-    "discharge_at_coords = model.get_value_at_coords('Discharge', lat=np.array([42.65]), lon=np.array([-71.35]))\n",
+    "discharge_at_coords = model.get_value_at_coords('Discharge', lon=[-71.35], lat=[42.65])\n",
     "discharge_at_coords"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
-   "id": "39a334ef",
+   "execution_count": 22,
+   "id": "a4d23415",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(array([-71.35]), array([42.65]))"
+       "(array([-71.35,   5.65]), array([42.65, 50.75]))"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# indices to coords\n",
-    "model.indices_to_coords('Discharge', np.array([1703886]))"
+    "model.indices_to_coords('Discharge', [1703886, 1413056])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "id": "fc267ee7",
+   "execution_count": 23,
+   "id": "cd848cbf",
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Your coordinates [[-71.35  42.65]\n",
+      " [  5.6   50.7 ]] match these model coordinates [array([-71.35,  42.65]), array([ 5.65, 50.65])].\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "array([1703886])"
+       "array([1703886, 1416656])"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# coords to indices\n",
-    "model.coords_to_indices('Discharge',  lat=np.array([42.65]), lon=np.array([-71.35]))"
+    "model.coords_to_indices('Discharge',  lon=[-71.35, 5.6], lat=[42.65, 50.7])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
-   "id": "cd557214",
+   "execution_count": 24,
+   "id": "598cb904",
    "metadata": {},
    "outputs": [],
    "source": [
     "# stop the model\n",
     "del model.bmi"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "066d8eed",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tests/models/test_abstract.py
+++ b/tests/models/test_abstract.py
@@ -32,10 +32,10 @@ class MockedModel(AbstractModel):
             attrs=dict(units="degC"),
         )
 
-    def coords_to_indices(self, name: str, lat: Iterable[float], lon: Iterable[float]) -> Iterable[int]:
+    def _coords_to_indices(self, name: str, lat: Iterable[float], lon: Iterable[float]) -> Iterable[int]:
         return np.array([0])
 
-    def indices_to_coords(self, name: str, indices: Iterable[int]) -> Tuple[Iterable[float], Iterable[float]]:
+    def _indices_to_coords(self, name: str, indices: Iterable[int]) -> Tuple[Iterable[float], Iterable[float]]:
         return np.array([-99.83]), np.array([42.25])
 
 
@@ -100,15 +100,6 @@ def test_get_value(bmi, model: MockedModel):
     assert_array_equal(value, expected)
 
 
-def test_get_value_at_indices(bmi, model: MockedModel):
-    expected = np.array([1.0])
-    bmi.get_value_at_indices.return_value = expected
-
-    value = model.get_value_at_indices('discharge', [0])
-
-    assert_array_equal(value, expected)
-
-
 def test_get_value_at_coords(bmi, model: MockedModel):
     expected = np.array([1.0])
     bmi.get_value_at_indices.return_value = expected
@@ -123,13 +114,6 @@ def test_set_value(model: MockedModel, bmi):
     model.set_value('precipitation', value)
 
     bmi.set_value.assert_called_once_with('precipitation', value)
-
-
-def set_value_at_indices(model: MockedModel, bmi):
-    value = np.array([1.0])
-    model.set_value_at_indices('precipitation', [0], value)
-
-    bmi.set_value_at_indices.assert_called_once_with('precipitation', [0], value)
 
 
 def test_set_value_at_coords(model: MockedModel, bmi):

--- a/tests/models/test_abstract.py
+++ b/tests/models/test_abstract.py
@@ -35,9 +35,6 @@ class MockedModel(AbstractModel):
     def _coords_to_indices(self, name: str, lat: Iterable[float], lon: Iterable[float]) -> Tuple[Iterable[int], Iterable[float], Iterable[float]]:
         return np.array([0]), np.array([-99.83]), np.array([42.25])
 
-    def _indices_to_coords(self, name: str, indices: Iterable[int]) -> Tuple[Iterable[float], Iterable[float]]:
-        return np.array([-99.83]), np.array([42.25])
-
 
     @property
     def parameters(self) -> Iterable[Tuple[str, Any]]:

--- a/tests/models/test_abstract.py
+++ b/tests/models/test_abstract.py
@@ -32,10 +32,10 @@ class MockedModel(AbstractModel):
             attrs=dict(units="degC"),
         )
 
-    def coords_to_indices(self, name: str, lat: np.ndarray, lon: np.ndarray) -> np.ndarray:
+    def coords_to_indices(self, name: str, lat: Iterable[float], lon: Iterable[float]) -> Iterable[int]:
         return np.array([0])
 
-    def indices_to_coords(self, name: str, indices: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def indices_to_coords(self, name: str, indices: Iterable[int]) -> Tuple[Iterable[float], Iterable[float]]:
         return np.array([-99.83]), np.array([42.25])
 
 
@@ -104,7 +104,7 @@ def test_get_value_at_indices(bmi, model: MockedModel):
     expected = np.array([1.0])
     bmi.get_value_at_indices.return_value = expected
 
-    value = model.get_value_at_indices('discharge', np.array([0.0]))
+    value = model.get_value_at_indices('discharge', [0])
 
     assert_array_equal(value, expected)
 
@@ -113,7 +113,7 @@ def test_get_value_at_coords(bmi, model: MockedModel):
     expected = np.array([1.0])
     bmi.get_value_at_indices.return_value = expected
 
-    value = model.get_value_at_coords('discharge', np.array([-99.83]), np.array([42.25]))
+    value = model.get_value_at_coords('discharge', [-99.83], [42.25])
 
     assert_array_equal(value, expected)
 
@@ -127,16 +127,16 @@ def test_set_value(model: MockedModel, bmi):
 
 def set_value_at_indices(model: MockedModel, bmi):
     value = np.array([1.0])
-    model.set_value_at_indices('precipitation', np.array([0.0]), value)
+    model.set_value_at_indices('precipitation', [0], value)
 
-    bmi.set_value_at_indices.assert_called_once_with('precipitation', np.array([0.0]), value)
+    bmi.set_value_at_indices.assert_called_once_with('precipitation', [0], value)
 
 
 def test_set_value_at_coords(model: MockedModel, bmi):
     value = np.array([1.0])
-    model.set_value_at_coords('precipitation', np.array([-99.83]), np.array([42.25]), value)
+    model.set_value_at_coords('precipitation', [-99.83], [42.25], value)
 
-    bmi.set_value_at_indices.assert_called_once_with('precipitation', np.array([0.0]), value)
+    bmi.set_value_at_indices.assert_called_once_with('precipitation', [0], value)
 
 
 def test_start_time(bmi, model: MockedModel):

--- a/tests/models/test_abstract.py
+++ b/tests/models/test_abstract.py
@@ -32,8 +32,8 @@ class MockedModel(AbstractModel):
             attrs=dict(units="degC"),
         )
 
-    def _coords_to_indices(self, name: str, lat: Iterable[float], lon: Iterable[float]) -> Iterable[int]:
-        return np.array([0])
+    def _coords_to_indices(self, name: str, lat: Iterable[float], lon: Iterable[float]) -> Tuple[Iterable[int], Iterable[float], Iterable[float]]:
+        return np.array([0]), np.array([-99.83]), np.array([42.25])
 
     def _indices_to_coords(self, name: str, indices: Iterable[int]) -> Tuple[Iterable[float], Iterable[float]]:
         return np.array([-99.83]), np.array([42.25])

--- a/tests/models/test_lisflood.py
+++ b/tests/models/test_lisflood.py
@@ -136,6 +136,7 @@ class TestLFlatlonUseCase:
 
 
 class MockedBmi(Bmi):
+    """Mimic a real use case with realistic shape and abitrary high precision."""
     def get_var_grid(self, name):
         return 0
 
@@ -166,7 +167,6 @@ class MockedBmi(Bmi):
     def get_value_at_indices(self, name, indices):
         self.indices = indices
         return np.array([1.0])
-
 
 
 

--- a/tests/models/test_lisflood.py
+++ b/tests/models/test_lisflood.py
@@ -3,8 +3,11 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from numpy.testing import assert_array_equal
+import numpy as np
 
 from grpc4bmi.bmi_client_singularity import BmiClientSingularity
+from basic_modeling_interface import Bmi
 
 from ewatercycle import CFG
 from ewatercycle.forcing import load_foreign
@@ -109,3 +112,61 @@ class TestLFlatlonUseCase:
             textvar_name = textvar.attrib["name"]
             if textvar_name == 'IrrigationEfficiency':
                 assert textvar.get('value') == '0.8'
+
+    class TestGetValueAtCoords():
+
+        def test_get_value_at_coords_single(self, model: Lisflood):
+            expected = np.array([1.0])
+            model.bmi = MockedBmi()
+            actual = model.get_value_at_coords('Discharge', lon=[-124.35], lat=[52.93])
+            assert_array_equal(actual, expected)
+            assert model.bmi.indices == [311]
+
+        def test_get_value_at_coords_multiple(self, model: Lisflood):
+            model.bmi = MockedBmi()
+            model.get_value_at_coords('Discharge', lon=[-124.45, -124.35, -121.45], lat=[53.95, 52.93, 52.65])
+            assert_array_equal(model.bmi.indices, [0, 311, 433])
+
+        def test_get_value_at_coords_faraway(self, model: Lisflood):
+            model.bmi = MockedBmi()
+            with pytest.raises(ValueError) as excinfo:
+                    model.get_value_at_coords('Discharge', lon=[0.0], lat=[0.0])
+            msg = str(excinfo.value)
+            assert "This point is outside of the model grid." in msg
+
+
+class MockedBmi(Bmi):
+    def get_var_grid(self, name):
+        return 0
+
+    def get_grid_shape(self, grid_id):
+        return (14, 31) #shape returns (len(y), len(x))
+
+    def get_grid_x(self, grid_id):
+         return np.array([-124.450000000003, -124.350000000003, -124.250000000003,
+                -124.150000000003, -124.050000000003, -123.950000000003,
+                -123.850000000003, -123.750000000003, -123.650000000003,
+                -123.550000000003, -123.450000000003, -123.350000000003,
+                -123.250000000003, -123.150000000003, -123.050000000003,
+                -122.950000000003, -122.850000000003, -122.750000000003,
+                -122.650000000003, -122.550000000003, -122.450000000003,
+                -122.350000000003, -122.250000000003, -122.150000000003,
+                -122.050000000003, -121.950000000003, -121.850000000003,
+                -121.750000000003, -121.650000000003, -121.550000000003, -121.450000000003])
+
+    def get_grid_y(self, grid_id):
+         return np.array([53.950000000002, 53.8500000000021, 53.7500000000021, 53.6500000000021,
+                53.5500000000021, 53.4500000000021, 53.3500000000021, 53.2500000000021,
+                53.1500000000021, 53.0500000000021, 52.9500000000021, 52.8500000000021,
+                52.7500000000021, 52.6500000000021 ])
+
+    def get_grid_spacing(self, grid_id):
+        return (0.1, 0.1)
+
+    def get_value_at_indices(self, name, indices):
+        self.indices = indices
+        return np.array([1.0])
+
+
+
+

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -26,9 +26,9 @@ def test_get_time_without_tz():
 
 
 def test_find_closest_point():
-    actual_distances, actual_index = (
+    expected_distances, expected_index = (
         [[118.77417243, 111.22983323],[122.9552163 , 115.67902656]],
         1)
-    expected_distances, expected_index = find_closest_point([-99.83, -99.32], [42.25, 42.21], -99.32, 43.25)
+    actual_distances, actual_index = find_closest_point([-99.83, -99.32], [42.25, 42.21], -99.32, 43.25)
     assert_array_almost_equal(actual_distances, expected_distances)
     assert actual_index == expected_index

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,7 +2,8 @@ from datetime import datetime, timezone
 
 import pytest
 
-from ewatercycle.util import get_time
+from ewatercycle.util import get_time, find_closest_point
+from numpy.testing import assert_array_almost_equal
 
 
 def test_get_time_with_utc():
@@ -23,3 +24,11 @@ def test_get_time_without_tz():
 
     assert 'not in UTC' in str(excinfo.value)
 
+
+def test_find_closest_point():
+    actual_distances, actual_index = (
+        [[118.77417243, 111.22983323],[122.9552163 , 115.67902656]],
+        1)
+    expected_distances, expected_index = find_closest_point([-99.83, -99.32], [42.25, 42.21], -99.32, 43.25)
+    assert_array_almost_equal(actual_distances, expected_distances)
+    assert actual_index == expected_index


### PR DESCRIPTION
The new functions are also implemented for lisflood and shown in the lisflood example notebook in this PR. To check if new functions return correct values in the example notebook, you can use [this notebook](https://github.com/eWaterCycle/era5-comparison/blob/master/lisflood/02_lisflood_testrun.ipynb) as a reference: the model indices and their coordinates for some of the catchments are shown in cell No. 9.

Closes #53 