### PR TITLE
Fix if statement in _generate_work_dir for marrmot

### DIFF
--- a/ewatercycle/models/marrmot.py
+++ b/ewatercycle/models/marrmot.py
@@ -30,14 +30,14 @@ class Solver:
 def _generate_work_dir(work_dir: Path = None) -> Path:
     """
     Args:
-        work_dir: If work dir is None then create sub-directory in CFG['output_dir']
+        work_dir: If work dir is None or does not exist then create sub-directory in CFG['output_dir']
     """
     if work_dir is None:
         scratch_dir = CFG['output_dir']
         # TODO this timestamp isnot safe for parallel processing
         timestamp = time.strftime("%Y%m%d_%H%M%S")
         work_dir = Path(scratch_dir) / f'marrmot_{timestamp}'
-        work_dir.mkdir(parents=True, exist_ok=True)
+    work_dir.mkdir(parents=True, exist_ok=True)
     return work_dir
 
 

--- a/tests/models/test_marrmotm01.py
+++ b/tests/models/test_marrmotm01.py
@@ -115,6 +115,13 @@ class TestWithDefaultsAndExampleData:
         )
         assert cfg_dir == tmp_path
 
+    def test_setup_create_work_dir(self, tmp_path, mocked_config, model: MarrmotM01):
+        work_dir = tmp_path / 'output'
+        cfg_file, cfg_dir = model.setup(
+            work_dir=work_dir
+        )
+        assert cfg_dir == work_dir
+
 
 class TestWithCustomSetupAndExampleData:
     @pytest.fixture

--- a/tests/models/test_marrmotm14.py
+++ b/tests/models/test_marrmotm14.py
@@ -128,6 +128,13 @@ class TestWithDefaultsAndExampleData:
         )
         assert cfg_dir == tmp_path
 
+    def test_setup_create_work_dir(self, tmp_path, mocked_config, model: MarrmotM14):
+        work_dir = tmp_path / 'output'
+        cfg_file, cfg_dir = model.setup(
+            work_dir=work_dir
+        )
+        assert cfg_dir == work_dir
+
 
 class TestWithCustomSetupAndExampleData:
     @pytest.fixture


### PR DESCRIPTION
In this fix if the work_dir does not exist, then the setup() will create it. This is needed when running the calibration.