### PR TITLE
Change master references to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: Python package
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
       types: [opened, synchronize, reopened]
 

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -2,7 +2,7 @@ name: SonarCloud analysis
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
       types: [opened, synchronize, reopened]
 
@@ -31,7 +31,7 @@ jobs:
     - name: Correct coverage paths
       run: sed -i "s+$PWD/++g" coverage.xml
     - name: SonarCloud Scan
-      uses: sonarsource/sonarcloud-github-action@master
+      uses: sonarsource/sonarcloud-github-action@main
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Correct coverage paths
       run: sed -i "s+$PWD/++g" coverage.xml
     - name: SonarCloud Scan
-      uses: sonarsource/sonarcloud-github-action@main
+      uses: sonarsource/sonarcloud-github-action@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -39,7 +39,7 @@ You want to make some kind of change to the code base
 
 1. (**important**) announce your plan to the rest of the community *before you start working*. This announcement should be in the form of a (new) issue;
 2. (**important**) wait until some kind of consensus is reached about your idea being a good idea;
-3. if needed, fork the repository to your own Github profile and create your own feature branch off of the latest master commit. While working on your feature branch, make sure to stay up to date with the master branch by pulling in changes, possibly from the 'upstream' repository (follow the instructions `here <https://help.github.com/articles/configuring-a-remote-for-a-fork/>`_ and `here <https://help.github.com/articles/syncing-a-fork/>`_);
+3. if needed, fork the repository to your own Github profile and create your own feature branch off of the latest main commit. While working on your feature branch, make sure to stay up to date with the main branch by pulling in changes, possibly from the 'upstream' repository (follow the instructions `here <https://help.github.com/articles/configuring-a-remote-for-a-fork/>`_ and `here <https://help.github.com/articles/syncing-a-fork/>`_);
 4. install the package in editable mode and its dependencies with ``pip3 install -e .[dev]``;
 5. make sure the existing tests still work by running ``pytest``;
 6. make sure the existing documentation can still by generated without warnings by running ``cd docs && make html``;

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ dependencies:
 
 .. code-block:: bash
 
-    wget https://raw.githubusercontent.com/eWaterCycle/ewatercycle/master/environment.yml
+    wget https://raw.githubusercontent.com/eWaterCycle/ewatercycle/main/environment.yml
     conda env create --file environment.yml
     conda activate ewatercycle
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,3 +1,3 @@
 This is a small collection of example notebooks for the eWaterCycle package.
 
-If GitHub fails to render these notebooks, you can also view them using the Jupyter nbviewer here: https://nbviewer.jupyter.org/github/eWaterCycle/ewatercycle/tree/master/examples/
+If GitHub fails to render these notebooks, you can also view them using the Jupyter nbviewer here: https://nbviewer.jupyter.org/github/eWaterCycle/ewatercycle/tree/main/examples/

--- a/docs/hpc_to_cluster.rst
+++ b/docs/hpc_to_cluster.rst
@@ -98,7 +98,7 @@ https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environme
 
 Make sure that Jupyter Lab is installed in the Conda environment:
 
-- ``wget https://raw.githubusercontent.com/eWaterCycle/ewatercycle/master/environment.yml``
+- ``wget https://raw.githubusercontent.com/eWaterCycle/ewatercycle/main/environment.yml``
 - ``conda env create --file environment.yml``
 - ``conda activate ewatercycle``
 - ``conda install -c conda-forge jupyterlab``

--- a/docs/system_setup.rst
+++ b/docs/system_setup.rst
@@ -32,11 +32,11 @@ installer <https://docs.conda.io/en/latest/miniconda.html>`__.
 
 After conda is installed you can install the software dependencies with
 a `conda environment
-file <https://github.com/eWaterCycle/ewatercycle/blob/master/environment.yml>`__.
+file <https://github.com/eWaterCycle/ewatercycle/blob/main/environment.yml>`__.
 
 .. code:: shell
 
-    wget https://raw.githubusercontent.com/eWaterCycle/ewatercycle/master/environment.yml
+    wget https://raw.githubusercontent.com/eWaterCycle/ewatercycle/main/environment.yml
 
 .. code:: shell
 


### PR DESCRIPTION
We renamed the master branch to main, but there were still some pointers to master in our CI workflows and other references in the code or documentation. This PR renames all instances of master to main.

Related to #177 (not sure it will fix it)