### PR TITLE
Add NLeSC community to zenodo

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -57,5 +57,10 @@
     "license": {
         "id": "Apache-2.0"
     },
-    "title": "eWaterCycle Python package"
+    "title": "eWaterCycle Python package", 
+    "communities": [
+      {
+        "id": "nlesc"
+      }
+    ]
 }


### PR DESCRIPTION
This PR should add NLeSC community to any new Zenodo records made.

Current Zenodo entry also has NLeSC community added.