### PR TITLE
Pin esmpy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Formatted as described on [https://keepachangelog.com](https://keepachangelog.co
 
 - ParameterSet can be outside CFG['parametersets_dir'] ([#217](https://github.com/eWaterCycle/ewatercycle/issues/217))
 - Link to nbviewer ([#202](https://github.com/eWaterCycle/ewatercycle/issues/202))
+- Pinned esmpy as temporary workaround for single CPU affinity ([#234](https://github.com/eWaterCycle/ewatercycle/issues/234))
 
 ### Removed
 

--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,6 @@ dependencies:
   - python>=3.7
   - esmvaltool-python>=2.3.0
   - subversion
+  # Pin esmpy so we dont get forced to run all parallel tasks on single cpu
+  # Can be removed once https://github.com/ESMValGroup/ESMValCore/issues/1208 is resolved.
+  - esmpy!=8.1.0


### PR DESCRIPTION
Fixes #234

Tested with
```shell
conda env create -n ewc-pinned-esmpy --file environment.yml
conda activate ewc-pinned-esmpy
python
```
and
```pycon
>>> import os
>>> import esmvalcore
>>> pid = os.getpid()
>>> print(os.sched_getaffinity(pid))
{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
>>> import esmvalcore.preprocessor
>>> print(os.sched_getaffinity(pid))
{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
>>> import esmvalcore.experimental
>>> print(os.sched_getaffinity(pid))
{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
```
If `{0}` was printed it would have been bad.
