### PR TITLE
Dont mock ruamel.yaml during `make html`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -205,7 +205,6 @@ autodoc_mock_imports = [
     "pyoos",
     "grpc4bmi",
     "grpc",
-    "ruamel.yaml",
     "scipy",
     "xarray",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,7 @@ dev =
     pytest-runner
     recommonmark
     sphinx
+    sphinx-copybutton
     sphinx_rtd_theme
     twine
     types-python-dateutil


### PR DESCRIPTION
Fixes #169

Running `cd docs && make html` works locally and [build on readthedocs](https://readthedocs.org/projects/ewatercycle/builds/14804992/) is also works.