### PR TITLE
Dont call finalize() on Lisflood.bmi when Lisflood.finalize() is call…

### DIFF
--- a/docs/examples/lisflood.ipynb
+++ b/docs/examples/lisflood.ipynb
@@ -475,7 +475,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.__del__()"
+    "model.finalize()"
    ]
   },
   {

--- a/src/ewatercycle/models/lisflood.py
+++ b/src/ewatercycle/models/lisflood.py
@@ -306,6 +306,11 @@ class Lisflood(AbstractModel[LisfloodForcing]):
             ("end_time", self._end.strftime("%Y-%m-%dT%H:%M:%SZ")),
         ]
 
+    def finalize(self) -> None:
+        """Perform tear-down tasks for the model."""
+        # Finalize function of bmi class of lisflood is kaput, so not calling it
+        del self.bmi
+
 
 # TODO it needs fix regarding forcing
 # def reindex_forcings(


### PR DESCRIPTION
…ed. Only perform container clean up

Refs eWaterCycle/ewatercycle-lisflood#5