### PR TITLE
Add directory argument to forcing.generate()

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: setup-cfg-fmt
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: "22.3.0"
     hooks:
       - id: black-jupyter
   - repo: https://github.com/PyCQA/isort

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Formatted as described on [https://keepachangelog.com](https://keepachangelog.co
 
 ## [Unreleased]
 
+### Added
+
+- Directory argument to `ewatercycle.forcing.generate()` ([#145](https://github.com/eWaterCycle/ewatercycle/issues/145))
+
 ### Changed
 
 - Improved performance of forcing generation of LISFLOOD model ([#301](https://github.com/eWaterCycle/ewatercycle/pull/301))

--- a/src/ewatercycle/forcing/__init__.py
+++ b/src/ewatercycle/forcing/__init__.py
@@ -127,6 +127,7 @@ def generate(
     start_time: str,
     end_time: str,
     shape: str,
+    directory: Optional[str] = None,
     model_specific_options: Optional[Dict] = None,
 ):
     """Generate forcing data with ESMValTool.
@@ -139,6 +140,8 @@ def generate(
         end_time: End time of forcing in UTC and ISO format string e.g.
             'YYYY-MM-DDTHH:MM:SSZ'.
         shape: Path to a shape file. Used for spatial selection.
+        directory: Directory in which forcing should be written.
+            If not given will create timestamped directory.
         model_specific_options: Dictionary with model-specific recipe settings.
             See below for the available options for each model.
 
@@ -157,7 +160,12 @@ def generate(
     if model_specific_options is None:
         model_specific_options = {}
     forcing_info = constructor.generate(
-        dataset, start_time, end_time, shape, **model_specific_options
+        dataset,
+        start_time,
+        end_time,
+        shape,
+        directory=directory,
+        **model_specific_options,
     )
     forcing_info.save()
     return forcing_info

--- a/src/ewatercycle/forcing/_default.py
+++ b/src/ewatercycle/forcing/_default.py
@@ -1,8 +1,11 @@
 """Forcing related functionality for default models"""
 import logging
 from copy import copy
+from pathlib import Path
 from typing import Optional
 
+from esmvalcore.experimental import CFG
+from esmvalcore.experimental.config import Session
 from ruamel.yaml import YAML
 
 from ewatercycle.util import to_absolute_path
@@ -53,6 +56,7 @@ class DefaultForcing:
         start_time: str,
         end_time: str,
         shape: str,
+        directory: Optional[str] = None,
         **model_specific_options,
     ) -> "DefaultForcing":
         """Generate forcing data with ESMValTool."""
@@ -87,3 +91,20 @@ class DefaultForcing:
 
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
+
+
+def _session(directory: Optional[str] = None) -> Optional[Session]:
+    """When directory is set return a ESMValTool session that will write recipe output to that directory."""
+    if directory is None:
+        return None
+
+    class TimeLessSession(Session):
+        def __init__(self, output_dir: Path):
+            super().__init__(CFG.copy())
+            self.output_dir = output_dir
+
+        @property
+        def session_dir(self):
+            return self.output_dir
+
+    return TimeLessSession(Path(directory))

--- a/src/ewatercycle/forcing/_default.py
+++ b/src/ewatercycle/forcing/_default.py
@@ -107,4 +107,4 @@ def _session(directory: Optional[str] = None) -> Optional[Session]:
         def session_dir(self):
             return self.output_dir
 
-    return TimeLessSession(Path(directory))
+    return TimeLessSession(Path(directory).absolute())

--- a/src/ewatercycle/forcing/_hype.py
+++ b/src/ewatercycle/forcing/_hype.py
@@ -63,7 +63,7 @@ class HypeForcing(DefaultForcing):
             variables[var_name]["end_year"] = endyear
 
         # generate forcing data and retreive useful information
-        recipe_output = recipe.run(_session(directory))
+        recipe_output = recipe.run(session=_session(directory))
         # TODO return files created by ESMValTOOL which are needed by Hype Model
         # forcing_path = list(recipe_output['...........']).data_files[0]
         forcing_path = "/foobar.txt"

--- a/src/ewatercycle/forcing/_hype.py
+++ b/src/ewatercycle/forcing/_hype.py
@@ -6,7 +6,7 @@ from typing import Optional
 from esmvalcore.experimental import get_recipe
 
 from ..util import get_time, to_absolute_path
-from ._default import DefaultForcing
+from ._default import DefaultForcing, _session
 from .datasets import DATASETS
 
 
@@ -27,7 +27,12 @@ class HypeForcing(DefaultForcing):
 
     @classmethod
     def generate(  # type: ignore
-        cls, dataset: str, start_time: str, end_time: str, shape: str
+        cls,
+        dataset: str,
+        start_time: str,
+        end_time: str,
+        shape: str,
+        directory: Optional[str] = None,
     ) -> "HypeForcing":
         """
         None: Hype does not have model-specific generate options.
@@ -58,7 +63,7 @@ class HypeForcing(DefaultForcing):
             variables[var_name]["end_year"] = endyear
 
         # generate forcing data and retreive useful information
-        recipe_output = recipe.run()
+        recipe_output = recipe.run(_session(directory))
         # TODO return files created by ESMValTOOL which are needed by Hype Model
         # forcing_path = list(recipe_output['...........']).data_files[0]
         forcing_path = "/foobar.txt"

--- a/src/ewatercycle/forcing/_lisflood.py
+++ b/src/ewatercycle/forcing/_lisflood.py
@@ -14,7 +14,7 @@ from ..util import (
     reindex,
     to_absolute_path,
 )
-from ._default import DefaultForcing
+from ._default import DefaultForcing, _session
 from ._lisvap import create_lisvap_config, lisvap
 from .datasets import DATASETS
 
@@ -63,6 +63,7 @@ class LisfloodForcing(DefaultForcing):
         start_time: str,
         end_time: str,
         shape: str,
+        directory: Optional[str] = None,
         target_grid: dict = None,
         run_lisvap: dict = None,
     ) -> "LisfloodForcing":
@@ -158,7 +159,7 @@ class LisfloodForcing(DefaultForcing):
         # ValueError: The 'longitude' DimCoord points array must be strictly monotonic.
 
         # generate forcing data and retrieve useful information
-        recipe_output = recipe.run()
+        recipe_output = recipe.run(_session(directory))
         directory, forcing_files = data_files_from_recipe_output(recipe_output)
 
         if run_lisvap:

--- a/src/ewatercycle/forcing/_lisflood.py
+++ b/src/ewatercycle/forcing/_lisflood.py
@@ -159,7 +159,7 @@ class LisfloodForcing(DefaultForcing):
         # ValueError: The 'longitude' DimCoord points array must be strictly monotonic.
 
         # generate forcing data and retrieve useful information
-        recipe_output = recipe.run(_session(directory))
+        recipe_output = recipe.run(session=_session(directory))
         directory, forcing_files = data_files_from_recipe_output(recipe_output)
 
         if run_lisvap:

--- a/src/ewatercycle/forcing/_marrmot.py
+++ b/src/ewatercycle/forcing/_marrmot.py
@@ -69,7 +69,7 @@ class MarrmotForcing(DefaultForcing):
             variables[var_name]["end_year"] = endyear
 
         # generate forcing data and retrieve useful information
-        recipe_output = recipe.run(_session(directory))
+        recipe_output = recipe.run(session=_session(directory))
         forcing_file: Path = list(recipe_output.values())[0].files[0].path
 
         directory = str(Path(forcing_file).parent)

--- a/src/ewatercycle/forcing/_marrmot.py
+++ b/src/ewatercycle/forcing/_marrmot.py
@@ -6,7 +6,7 @@ from typing import Optional
 from esmvalcore.experimental import get_recipe
 
 from ..util import get_time, to_absolute_path
-from ._default import DefaultForcing
+from ._default import DefaultForcing, _session
 from .datasets import DATASETS
 
 
@@ -36,6 +36,7 @@ class MarrmotForcing(DefaultForcing):
         start_time: str,
         end_time: str,
         shape: str,
+        directory: Optional[str] = None,
     ) -> "MarrmotForcing":
         """
         None: Marrmot does not have model-specific generate options.
@@ -68,7 +69,7 @@ class MarrmotForcing(DefaultForcing):
             variables[var_name]["end_year"] = endyear
 
         # generate forcing data and retrieve useful information
-        recipe_output = recipe.run()
+        recipe_output = recipe.run(_session(directory))
         forcing_file: Path = list(recipe_output.values())[0].files[0].path
 
         directory = str(Path(forcing_file).parent)

--- a/src/ewatercycle/forcing/_pcrglobwb.py
+++ b/src/ewatercycle/forcing/_pcrglobwb.py
@@ -106,7 +106,7 @@ class PCRGlobWBForcing(DefaultForcing):
             variables[var_name]["end_year"] = endyear_climatology
 
         # generate forcing data and retrieve useful information
-        recipe_output = recipe.run(_session(directory))
+        recipe_output = recipe.run(session=_session(directory))
         # TODO dont open recipe output, but use standard name from ESMValTool
         directory, forcing_files = data_files_from_recipe_output(recipe_output)
 

--- a/src/ewatercycle/forcing/_pcrglobwb.py
+++ b/src/ewatercycle/forcing/_pcrglobwb.py
@@ -11,7 +11,7 @@ from ..util import (
     get_time,
     to_absolute_path,
 )
-from ._default import DefaultForcing
+from ._default import DefaultForcing, _session
 from .datasets import DATASETS
 
 
@@ -45,6 +45,7 @@ class PCRGlobWBForcing(DefaultForcing):
         start_time_climatology: str,  # TODO make optional, default to start_time
         end_time_climatology: str,  # TODO make optional, defaults to start_time + 1 y
         extract_region: dict = None,
+        directory: Optional[str] = None,
     ) -> "PCRGlobWBForcing":
         """
         start_time_climatology (str): Start time for the climatology data
@@ -105,7 +106,7 @@ class PCRGlobWBForcing(DefaultForcing):
             variables[var_name]["end_year"] = endyear_climatology
 
         # generate forcing data and retrieve useful information
-        recipe_output = recipe.run()
+        recipe_output = recipe.run(_session(directory))
         # TODO dont open recipe output, but use standard name from ESMValTool
         directory, forcing_files = data_files_from_recipe_output(recipe_output)
 

--- a/src/ewatercycle/forcing/_wflow.py
+++ b/src/ewatercycle/forcing/_wflow.py
@@ -90,7 +90,7 @@ class WflowForcing(DefaultForcing):
             variables[var_name]["end_year"] = endyear
 
         # generate forcing data and retreive useful information
-        recipe_output = recipe.run(_session(directory))
+        recipe_output = recipe.run(session=_session(directory))
         forcing_data = recipe_output["wflow_daily/script"].data_files[0]
 
         forcing_file = forcing_data.path

--- a/src/ewatercycle/forcing/_wflow.py
+++ b/src/ewatercycle/forcing/_wflow.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional
 from esmvalcore.experimental import get_recipe
 
 from ..util import get_extents, get_time, to_absolute_path
-from ._default import DefaultForcing
+from ._default import DefaultForcing, _session
 from .datasets import DATASETS
 
 
@@ -49,6 +49,7 @@ class WflowForcing(DefaultForcing):
         end_time: str,
         shape: str,
         dem_file: str,
+        directory: Optional[str] = None,
         extract_region: Dict[str, float] = None,
     ) -> "WflowForcing":
         """
@@ -89,7 +90,7 @@ class WflowForcing(DefaultForcing):
             variables[var_name]["end_year"] = endyear
 
         # generate forcing data and retreive useful information
-        recipe_output = recipe.run()
+        recipe_output = recipe.run(_session(directory))
         forcing_data = recipe_output["wflow_daily/script"].data_files[0]
 
         forcing_file = forcing_data.path

--- a/src/ewatercycle/util.py
+++ b/src/ewatercycle/util.py
@@ -43,7 +43,7 @@ def find_closest_point(
 
     # approximate radius of earth in km
     radius = 6373.0
-    distances = radius * np.sqrt(dlat ** 2 + (np.cos(latm) * dlon) ** 2)
+    distances = radius * np.sqrt(dlat**2 + (np.cos(latm) * dlon) ** 2)
     idx_lat, idx_lon = np.unravel_index(distances.argmin(), distances.shape)
     distance = distances.min()
 

--- a/tests/forcing/test_lisflood.py
+++ b/tests/forcing/test_lisflood.py
@@ -405,3 +405,20 @@ class TestGenerateForcingWithoutTargetGrid:
             actual["preprocessors"]["daily_windspeed"]["regrid"]["target_grid"]
             == expected_target_grid
         )
+
+
+def test_generate_with_directory(
+    mock_recipe_run, sample_shape, tmp_path, sample_target_grid
+):
+    forcing_dir = tmp_path / "myforcing"
+    generate(
+        target_model="lisflood",
+        dataset="ERA5",
+        start_time="1989-01-02T00:00:00Z",
+        end_time="1999-01-02T00:00:00Z",
+        shape=sample_shape,
+        model_specific_options=dict(target_grid=sample_target_grid),
+        directory=forcing_dir,
+    )
+
+    assert mock_recipe_run["session"].session_dir == forcing_dir

--- a/tests/forcing/test_lisflood.py
+++ b/tests/forcing/test_lisflood.py
@@ -50,10 +50,11 @@ def mock_recipe_run(monkeypatch, tmp_path):
             create_netcdf("e", tmp_path / "lisflood_e.nc"),
         )
 
-    def mock_run(self):
+    def mock_run(self, session=None):
         """Store recipe for inspection and return dummy output."""
         nonlocal data
         data["data_during_run"] = self.data
+        data["session"] = session
         return {"diagnostic_daily/script": MockTaskOutput()}
 
     monkeypatch.setattr(Recipe, "run", mock_run)

--- a/tests/forcing/test_marrmot.py
+++ b/tests/forcing/test_marrmot.py
@@ -190,3 +190,17 @@ def test_load_foreign_without_forcing_info(sample_shape):
         forcing_file="marrmot.mat",
     )
     assert actual == expected
+
+
+def test_generate_with_directory(mock_recipe_run, sample_shape, tmp_path):
+    forcing_dir = tmp_path / "myforcing"
+    generate(
+        target_model="marrmot",
+        dataset="ERA5",
+        start_time="1989-01-02T00:00:00Z",
+        end_time="1999-01-02T00:00:00Z",
+        shape=sample_shape,
+        directory=forcing_dir,
+    )
+
+    assert mock_recipe_run["session"].session_dir == forcing_dir

--- a/tests/forcing/test_marrmot.py
+++ b/tests/forcing/test_marrmot.py
@@ -28,10 +28,11 @@ def mock_recipe_run(monkeypatch, tmp_path):
         fake_forcing_path = str(tmp_path / "marrmot.mat")
         files = (OutputFile(fake_forcing_path),)
 
-    def mock_run(self):
+    def mock_run(self, session=None):
         """Store recipe for inspection and return dummy output."""
         nonlocal recorder
         recorder["data_during_run"] = self.data
+        recorder["session"] = session
         return {"diagnostic_daily/script": MockTaskOutput()}
 
     monkeypatch.setattr(Recipe, "run", mock_run)

--- a/tests/forcing/test_pcrglobwb.py
+++ b/tests/forcing/test_pcrglobwb.py
@@ -82,3 +82,27 @@ class TestGenerateWithExtractRegion:
 
 # TODO test if recipe was generated correctlu
 # TODO test if yaml was written
+
+
+def test_with_directory(mock_recipe_run, sample_shape, tmp_path):
+    forcing_dir = tmp_path / "myforcing"
+    generate(
+        target_model="pcrglobwb",
+        dataset="ERA5",
+        start_time="1989-01-02T00:00:00Z",
+        end_time="1999-01-02T00:00:00Z",
+        shape=str(sample_shape),
+        directory=forcing_dir,
+        model_specific_options=dict(
+            start_time_climatology="1979-01-02T00:00:00Z",
+            end_time_climatology="1989-01-02T00:00:00Z",
+            extract_region={
+                "start_longitude": 10,
+                "end_longitude": 16.75,
+                "start_latitude": 7.25,
+                "end_latitude": 2.5,
+            },
+        ),
+    )
+
+    assert mock_recipe_run["session"].session_dir == forcing_dir

--- a/tests/forcing/test_pcrglobwb.py
+++ b/tests/forcing/test_pcrglobwb.py
@@ -36,10 +36,11 @@ def mock_recipe_run(monkeypatch, tmp_path):
             create_netcdf("tas", tmp_path / "pcrglobwb_tas.nc"),
         )
 
-    def mock_run(self):
+    def mock_run(self, session=None):
         """Store recipe for inspection and return dummy output."""
         nonlocal data
         data["data_during_run"] = self.data
+        data["session"] = session
         return {"diagnostic_daily/script": MockTaskOutput()}
 
     monkeypatch.setattr(Recipe, "run", mock_run)

--- a/tests/forcing/test_wflow.py
+++ b/tests/forcing/test_wflow.py
@@ -17,11 +17,12 @@ def mock_recipe_run(monkeypatch, tmp_path):
         fake_forcing_path = str(tmp_path / "wflow_forcing.nc")
         data_files = (DataFile(fake_forcing_path),)
 
-    def mock_run(self):
+    def mock_run(self, session=None):
         """Store recipe for inspection and return dummy output."""
         nonlocal data
         data["data_during_run"] = self.data
-        return {"wflow_daily/script": MockTaskOutput()}
+        data["session"] = session
+        return {"diagnostic_daily/script": MockTaskOutput()}
 
     monkeypatch.setattr(Recipe, "run", mock_run)
     return data

--- a/tests/forcing/test_wflow.py
+++ b/tests/forcing/test_wflow.py
@@ -150,3 +150,26 @@ class TestGenerateWithExtractRegion:
         forcing.shape = None
 
         assert forcing == saved_forcing
+
+
+def test_with_directory(mock_recipe_run, sample_shape, tmp_path):
+    forcing_dir = tmp_path / "myforcing"
+    generate(
+        target_model="wflow",
+        dataset="ERA5",
+        start_time="1989-01-02T00:00:00Z",
+        end_time="1999-01-02T00:00:00Z",
+        shape=sample_shape,
+        directory=forcing_dir,
+        model_specific_options=dict(
+            dem_file="wflow_parameterset/meuse/staticmaps/wflow_dem.map",
+            extract_region={
+                "start_longitude": 10,
+                "end_longitude": 16.75,
+                "start_latitude": 7.25,
+                "end_latitude": 2.5,
+            },
+        ),
+    )
+
+    assert mock_recipe_run["session"].session_dir == forcing_dir

--- a/tests/forcing/test_wflow.py
+++ b/tests/forcing/test_wflow.py
@@ -22,7 +22,7 @@ def mock_recipe_run(monkeypatch, tmp_path):
         nonlocal data
         data["data_during_run"] = self.data
         data["session"] = session
-        return {"diagnostic_daily/script": MockTaskOutput()}
+        return {"wflow_daily/script": MockTaskOutput()}
 
     monkeypatch.setattr(Recipe, "run", mock_run)
     return data


### PR DESCRIPTION
Give recipe.run a session with overwritten session dir

Refs #145

Tested by inside docs/examples/ directory running

```python
import ewatercycle.forcing
pcrglobwb_forcing2 = ewatercycle.forcing.generate(
    target_model="pcrglobwb",
    dataset="ERA5",
    start_time="1990-01-01T00:00:00Z",
    end_time="1990-12-31T00:00:00Z",
    shape="./data/Rhine/Rhine.shp",
    directory="pcrglob_rhine_mydir",
    model_specific_options={
        "start_time_climatology": "1990-01-01T00:00:00Z",
        "end_time_climatology": "1990-01-01T00:00:00Z",
    },
)
print(pcrglobwb_forcing2)
```

Outputted 
```
Forcing data for PCRGlobWB
--------------------------
Directory: /home/vagrant/ewatercycle/docs/examples/pcrglob_rhine_mydir/work/diagnostic_daily/script
Start time: 1990-01-01T00:00:00Z
End time: 1990-12-31T00:00:00Z
Shapefile: /home/vagrant/ewatercycle/docs/examples/data/Rhine/Rhine.shp
Additional information for model config:
  - temperatureNC: pcrglobwb_OBS6_ERA5_reanaly_1_day_tas_1990-1990_Rhine.nc
  - precipitationNC: pcrglobwb_OBS6_ERA5_reanaly_1_day_pr_1990-1990_Rhine.nc
```
The forcing where correctly written to the `pcrglob_rhine_mydir/` directory instead of something like `esmvaltool_output/recipe_pcrglobwb_20220414_072527/`.