### PR TITLE
Wait for configurable seconds to let Marrmot containers to start up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Formatted as described on [https://keepachangelog.com](https://keepachangelog.co
 
 ## [Unreleased]
 
+### Added
+
+- delay argument to `ewatercycle.models.Marrmot*.setup()_ ([#303](https://github.com/eWaterCycle/ewatercycle/issues/303))
+
 ## [1.3.0] (2022-04-20)
 
 ### Added

--- a/src/ewatercycle/models/marrmot.py
+++ b/src/ewatercycle/models/marrmot.py
@@ -103,6 +103,7 @@ class MarrmotM01(AbstractModel[MarrmotForcing]):
         end_time: str = None,
         solver: Solver = None,
         cfg_dir: str = None,
+        delay: int = 0,
     ) -> Tuple[str, str]:
         """Configure model run.
 
@@ -122,6 +123,8 @@ class MarrmotM01(AbstractModel[MarrmotForcing]):
                 'YYYY-MM-DDTHH:MM:SSZ'. If not given then forcing end time is used.
             solver: Solver settings
             cfg_dir: a run directory given by user or created for user.
+            delay: Number of seconds to wait before communicating with model.
+                Increase the delay when model takes a while to start.
 
         Returns:
             Path to config file and path to config directory
@@ -147,7 +150,7 @@ class MarrmotM01(AbstractModel[MarrmotForcing]):
                 image=str(self.singularity_image),
                 work_dir=str(cfg_dir_as_path),
                 timeout=300,
-                delay=3,
+                delay=delay,
             )
         elif CFG["container_engine"].lower() == "docker":
             self.bmi = BmiClientDocker(
@@ -155,7 +158,7 @@ class MarrmotM01(AbstractModel[MarrmotForcing]):
                 image_port=55555,
                 work_dir=str(cfg_dir_as_path),
                 timeout=300,
-                delay=3,
+                delay=delay,
             )
         else:
             raise ValueError(
@@ -360,6 +363,7 @@ class MarrmotM14(AbstractModel[MarrmotForcing]):
         end_time: str = None,
         solver: Solver = None,
         cfg_dir: str = None,
+        delay: int = 0,
     ) -> Tuple[str, str]:
         """Configure model run.
 
@@ -386,6 +390,8 @@ class MarrmotM14(AbstractModel[MarrmotForcing]):
                 'YYYY-MM-DDTHH:MM:SSZ'. If not given then forcing end time is used.
                 solver: Solver settings
             cfg_dir: a run directory given by user or created for user.
+            delay: Number of seconds to wait before communicating with model.
+                Increase the delay when model takes a while to start.
 
         Returns:
             Path to config file and path to config directory
@@ -416,7 +422,7 @@ class MarrmotM14(AbstractModel[MarrmotForcing]):
                 image=str(self.singularity_image),
                 work_dir=str(cfg_dir_as_path),
                 timeout=300,
-                delay=3,
+                delay=delay,
             )
         elif CFG["container_engine"].lower() == "docker":
             self.bmi = BmiClientDocker(
@@ -424,7 +430,7 @@ class MarrmotM14(AbstractModel[MarrmotForcing]):
                 image_port=55555,
                 work_dir=str(cfg_dir_as_path),
                 timeout=300,
-                delay=3,
+                delay=delay,
             )
         else:
             raise ValueError(

--- a/src/ewatercycle/models/marrmot.py
+++ b/src/ewatercycle/models/marrmot.py
@@ -147,6 +147,7 @@ class MarrmotM01(AbstractModel[MarrmotForcing]):
                 image=str(self.singularity_image),
                 work_dir=str(cfg_dir_as_path),
                 timeout=300,
+                delay=3,
             )
         elif CFG["container_engine"].lower() == "docker":
             self.bmi = BmiClientDocker(
@@ -154,6 +155,7 @@ class MarrmotM01(AbstractModel[MarrmotForcing]):
                 image_port=55555,
                 work_dir=str(cfg_dir_as_path),
                 timeout=300,
+                delay=3,
             )
         else:
             raise ValueError(
@@ -414,6 +416,7 @@ class MarrmotM14(AbstractModel[MarrmotForcing]):
                 image=str(self.singularity_image),
                 work_dir=str(cfg_dir_as_path),
                 timeout=300,
+                delay=3,
             )
         elif CFG["container_engine"].lower() == "docker":
             self.bmi = BmiClientDocker(
@@ -421,6 +424,7 @@ class MarrmotM14(AbstractModel[MarrmotForcing]):
                 image_port=55555,
                 work_dir=str(cfg_dir_as_path),
                 timeout=300,
+                delay=3,
             )
         else:
             raise ValueError(


### PR DESCRIPTION
Refs #303

<del>
For now I set it to 3 seconds.
I want to make the delay value configurable, but not sure how
1. Add delay arg to setup()
2. Add container_delay to ewatercycle.yaml

I prefer option 1, @Peter9192 which do you prefer?
</del>

Adds delay argument to Marrmot*.setup() with by 0 as default.