### PR TITLE
MARRMoT example forcing file incompatible

### DIFF
--- a/docs/system_setup.rst
+++ b/docs/system_setup.rst
@@ -407,12 +407,12 @@ Download example forcing
 To be able to run the Marrmot example notebooks you need a forcing file.
 You can use ``ewatercycle.forcing.generate()`` to make it or use an
 already prepared `forcing
-file <https://github.com/wknoben/MARRMoT/blob/master/BMI/Config/BMI_testcase_m01_BuffaloRiver_TN_USA.mat>`__.
+file <https://github.com/wknoben/MARRMoT/blob/dev-docker-BMI/BMI/Config/BMI_testcase_m01_BuffaloRiver_TN_USA.mat>`__.
 
 .. code:: shell
 
     cd docs/examples
-    wget https://github.com/wknoben/MARRMoT/raw/master/BMI/Config/BMI_testcase_m01_BuffaloRiver_TN_USA.mat
+    wget https://github.com/wknoben/MARRMoT/raw/dev-docker-BMI/BMI/Config/BMI_testcase_m01_BuffaloRiver_TN_USA.mat
     cd -
 
 Download observation data

--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,9 @@
 ---
-name: ewatercycle
+name: ewatercycle39
 channels:
   - conda-forge
 dependencies:
-  - python>=3.7
+  - python==3.9
   - esmvaltool-python>=2.3.0
   - subversion
   # Pin esmpy so we dont get forced to run all parallel tasks on single cpu

--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,9 @@
 ---
-name: ewatercycle39
+name: ewatercycle
 channels:
   - conda-forge
 dependencies:
-  - python==3.9
+  - python>=3.8
   - esmvaltool-python>=2.3.0
   - subversion
   # Pin esmpy so we dont get forced to run all parallel tasks on single cpu

--- a/setup.cfg
+++ b/setup.cfg
@@ -111,7 +111,6 @@ builder = html
 [mypy]
 ignore_missing_imports = True
 files = src, tests
-mypy_path = $MYPY_CONFIG_FILE_DIR/src
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
Got error `Exception calling application: Octave evaluation error:\nerror: structure has no member 'delta_t_days'\nerror: called from:\n    initialize at line 66, column 28` while running /docs/examples/MarrmotM01.ipynb notebook.

The setup doc says to download form master branch of MARRMoT repo, but that file is incompatible with model in container image (https://hub.docker.com/layers/marrmot-grpc4bmi/ewatercycle/marrmot-grpc4bmi/2020.11/images/sha256-b067ab307a191d6cd97ac61d026f314cc63525c800fd24543a42ccab68af00aa?context=explore).

Using forcing file from same branch as container image was build from made notebook work again.