### PR TITLE
Update CONTRIBUTING for pypi publish action

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,14 +93,10 @@ This section is for maintainers of the package.
     - Use version as title and tag version.
     - As description use intro text from README.md (to give context to
         Zenodo record) and changes from CHANGELOG.md
+    - Verify that the [Github publish action](https://github.com/eWaterCycle/ewatercycle/actions/workflows/python-publish.yml)
+        successfully uploaded the archives to [PyPI](https://pypi.org/project/ewatercycle/).
 
-9. Create a PyPI release.
-
-    1. Create distribution archives with `python3 -m build`.
-    2. Upload archives to PyPI with `twine upload dist/*` (use your
-        personal PyPI account).
-
-10. Verify
+9.  Verify
 
     1. Has [new Zenodo
         record](https://zenodo.org/search?page=1&size=20&q=ewatercycle)
@@ -111,4 +107,4 @@ This section is for maintainers of the package.
     3. Can new version be installed with pip using
         `pip3 install ewatercycle==<new version>`?
 
-11. Celebrate
+10. Celebrate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,8 +93,6 @@ This section is for maintainers of the package.
     - Use version as title and tag version.
     - As description use intro text from README.md (to give context to
         Zenodo record) and changes from CHANGELOG.md
-    - Verify that the [Github publish action](https://github.com/eWaterCycle/ewatercycle/actions/workflows/python-publish.yml)
-        successfully uploaded the archives to [PyPI](https://pypi.org/project/ewatercycle/).
 
 9.  Verify
 
@@ -104,7 +102,9 @@ This section is for maintainers of the package.
     2. Has [stable
         ReadTheDocs](https://ewatercycle.readthedocs.io/en/stable/) been
         updated?
-    3. Can new version be installed with pip using
+    3. Has the [Github publish action](https://github.com/eWaterCycle/ewatercycle/actions/workflows/python-publish.yml)
+        successfully uploaded the archives to [PyPI](https://pypi.org/project/ewatercycle/)?
+    4. Can new version be installed with pip using
         `pip3 install ewatercycle==<new version>`?
 
 10. Celebrate


### PR DESCRIPTION
The `CONTRIBUTING.md` instructions for maintainers was not updated to reflect the added Github Action that publishes to PyPI upon release. This PR rectifies that.