### PR TITLE
Add missing model methods, documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Formatted as described on [https://keepachangelog.com](https://keepachangelog.co
 ### Added
 - Added the `input_var_names` property to the eWaterCycle model class, to accompany the existing `output_var_names` property ([#403](https://github.com/eWaterCycle/ewatercycle/pull/403)).
 - Added the `var_units` method to the eWaterCycle model class, to mirror PyMT ([#403](https://github.com/eWaterCycle/ewatercycle/pull/403)).
+- Added specification of the expected time units from the model's BMI to the documentation ([#403](https://github.com/eWaterCycle/ewatercycle/pull/403)).
 
 ### Changed
 - Updated the model documentation to link to the eWaterCycleModel API docs, and to make it a bit more clear that it is build on top of BMI ([#403](https://github.com/eWaterCycle/ewatercycle/pull/403)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Formatted as described on [https://keepachangelog.com](https://keepachangelog.co
 
 ## [Unreleased]
 
+### Added
+- Added the `input_var_names` property to the eWaterCycle model class, to accompany the existing `output_var_names` property.
+- Added the `var_units` method to the eWaterCycle model class, to mirror PyMT.
 
 ## [2.1.0] (2024-03-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Formatted as described on [https://keepachangelog.com](https://keepachangelog.co
 ### Added
 - Added the `input_var_names` property to the eWaterCycle model class, to accompany the existing `output_var_names` property ([#403](https://github.com/eWaterCycle/ewatercycle/pull/403)).
 - Added the `var_units` method to the eWaterCycle model class, to mirror PyMT ([#403](https://github.com/eWaterCycle/ewatercycle/pull/403)).
-- Added specification of the expected time units from the model's BMI to the documentation ([#403](https://github.com/eWaterCycle/ewatercycle/pull/403)).
+- Added a note on the time units that eWaterCycle expectes models to provide to the documentation ([#403](https://github.com/eWaterCycle/ewatercycle/pull/403)).
 
 ### Changed
 - Updated the model documentation to link to the eWaterCycleModel API docs, and to make it a bit more clear that it is build on top of BMI ([#403](https://github.com/eWaterCycle/ewatercycle/pull/403)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ Formatted as described on [https://keepachangelog.com](https://keepachangelog.co
 ## [Unreleased]
 
 ### Added
-- Added the `input_var_names` property to the eWaterCycle model class, to accompany the existing `output_var_names` property.
-- Added the `var_units` method to the eWaterCycle model class, to mirror PyMT.
+- Added the `input_var_names` property to the eWaterCycle model class, to accompany the existing `output_var_names` property ([#403](https://github.com/eWaterCycle/ewatercycle/pull/403)).
+- Added the `var_units` method to the eWaterCycle model class, to mirror PyMT ([#403](https://github.com/eWaterCycle/ewatercycle/pull/403)).
+
+### Changed
+- Updated the model documentation to link to the eWaterCycleModel API docs, and to make it a bit more clear that it is build on top of BMI ([#403](https://github.com/eWaterCycle/ewatercycle/pull/403)).
 
 ## [2.1.0] (2024-03-25)
 

--- a/docs/adding_models.rst
+++ b/docs/adding_models.rst
@@ -61,6 +61,10 @@ and should be implemented:
 * ``set_value_at_indices()``
 * ``set_value()``
 
+Note that for ``get_time_units()`` eWaterCycle expects are more specific string than the BMI specification.
+The output should be formatted in the form of ``<time_units> since <reference_time>``, for example: ``seconds since 1970-01-01 00:00:00.0 +0000``.
+More information on the format of the units can be found on the `cftime documentation <https://unidata.github.io/cftime/api.html#cftime.num2date>`_. 
+
 .. _eWaterCycle plugin:
 
 Add the model as eWaterCycle plugin

--- a/docs/user_guide/03_models_obs_analysis.ipynb
+++ b/docs/user_guide/03_models_obs_analysis.ipynb
@@ -30,18 +30,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "e8b58319",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "ERROR 1: PROJ: proj_create_from_database: Open of /home/bart/micromamba/envs/ewc3.11/share/proj failed\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from rich import print\n",
     "\n",
@@ -127,7 +119,9 @@
     "### Creating, setting up, and initializing a model instance\n",
     "\n",
     "The way models are created, setup, and initialized matches [PyMT](https://pymt.readthedocs.io/en/latest/quickstart.html#run-a-model) as much as possible.\n",
-    "There are three steps:\n",
+    "To see the all available methods and properties, see the [API reference for the eWaterCycleModel](../autoapi/ewatercycle/base/model/index.html#ewatercycle.base.model.eWaterCycleModel).\n",
+    "\n",
+    "There are three main steps required before running a model:\n",
     "\n",
     "- instantiate (create a python object that represents the model)\n",
     "- setup (create a container with the right model, directories, and configuration files)\n",
@@ -265,16 +259,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "c1103c60-acfd-4d85-a963-1dfda63dff05",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/home/bart/ewatercycle/output/wflow_20240312_151922/wflow_ewatercycle.ini\n"
-     ]
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800080; text-decoration-color: #800080\">/home/bart/ewatercycle/output/wflow_20240329_090300/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">wflow_ewatercycle.ini</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[35m/home/bart/ewatercycle/output/wflow_20240329_090300/\u001b[0m\u001b[95mwflow_ewatercycle.ini\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -292,7 +292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "37029f39",
    "metadata": {},
    "outputs": [],
@@ -315,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "e04303a6",
    "metadata": {},
    "outputs": [],
@@ -326,18 +326,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "9af1524b",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1991-12-15T00:00:00Z\r"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "output = []\n",
     "while model_instance.time < model_instance.end_time:\n",
@@ -368,17 +360,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "16ad7cc7",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x7f82e83849d0>"
+       "<matplotlib.collections.QuadMesh at 0x7fdb86ee6c90>"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -407,7 +399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "d1430796-ba02-4b77-a80d-1567e0ac7714",
    "metadata": {},
    "outputs": [
@@ -417,7 +409,7 @@
        "array([1850.8435], dtype=float32)"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -437,7 +429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "ff7774d6",
    "metadata": {},
    "outputs": [
@@ -447,13 +439,42 @@
        "('RiverRunoff',)"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "model_instance.output_var_names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a06cd42",
+   "metadata": {},
+   "source": [
+    "If you for some reason need to interact with the underlying Basic Model Interface of the model, you can access it in the following way:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "11b9092c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'sbm'"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model_instance.bmi.get_component_name()"
    ]
   },
   {

--- a/src/ewatercycle/base/model.py
+++ b/src/ewatercycle/base/model.py
@@ -437,7 +437,7 @@ class ContainerizedModel(eWaterCycleModel):
     def version(self) -> str:
         return self.bmi_image.version
 
-    def _make_bmi_instance(self) -> bmipy.Bmi:
+    def _make_bmi_instance(self) -> OptionalDestBmi:
         if self.parameter_set:
             self._additional_input_dirs.append(str(self.parameter_set.directory))
         if self.forcing:

--- a/src/ewatercycle/base/model.py
+++ b/src/ewatercycle/base/model.py
@@ -327,6 +327,15 @@ class eWaterCycleModel(BaseModel, abc.ABC):
         return self._bmi.get_output_var_names()
 
     @property
+    def input_var_names(self) -> Iterable[str]:
+        """List of a model's input variables."""
+        return self._bmi.get_input_var_names()
+
+    def var_units(self, name: str) -> str:
+        """Return the given variable's units."""
+        return self._bmi.get_var_units(name)
+
+    @property
     def start_time_as_isostr(self) -> str:
         """Start time of the model.
 


### PR DESCRIPTION
Closes #401 #402 

I've implemented the missing `var_units` and `input_var_names` model methods from PyMT.
The documentation is updated, to try to be a bit more clear about what methods are available (by linking to the API docs), and it's now explained how to access the _underlying_ bmi.

I also added a statement on the expected time_units to the model developer docs. Closes #379 