### PR TITLE
Catch error upon import of models more gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Formatted as described on [https://keepachangelog.com](https://keepachangelog.co
 
 ## [Unreleased]
 
+## Changed
+- If a model plugin raises an exception during the loading of the model entry points, a more clear exception is raised which guides the users on how to solve the error ([#404](https://github.com/eWaterCycle/ewatercycle/pull/404)).
 
 ## [2.1.0] (2024-03-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Formatted as described on [https://keepachangelog.com](https://keepachangelog.co
 ### Added
 - Added the `input_var_names` property to the eWaterCycle model class, to accompany the existing `output_var_names` property ([#403](https://github.com/eWaterCycle/ewatercycle/pull/403)).
 - Added the `var_units` method to the eWaterCycle model class, to mirror PyMT ([#403](https://github.com/eWaterCycle/ewatercycle/pull/403)).
-- Added a note on the time units that eWaterCycle expectes models to provide to the documentation ([#403](https://github.com/eWaterCycle/ewatercycle/pull/403)).
+- Added a note on the time units that eWaterCycle expects models to provide to the documentation ([#403](https://github.com/eWaterCycle/ewatercycle/pull/403)).
 
 ### Changed
 - If a model plugin raises an exception during the loading of the model entry points, a more clear exception is raised which guides the users on how to solve the error ([#404](https://github.com/eWaterCycle/ewatercycle/pull/404)).

--- a/docs/adding_models.rst
+++ b/docs/adding_models.rst
@@ -63,7 +63,7 @@ and should be implemented:
 
 Note that for ``get_time_units()`` eWaterCycle expects are more specific string than the BMI specification.
 The output should be formatted in the form of ``<time_units> since <reference_time>``, for example: ``seconds since 1970-01-01 00:00:00.0 +0000``.
-More information on the format of the units can be found on the `cftime documentation <https://unidata.github.io/cftime/api.html#cftime.num2date>`_. 
+More information on the format of the units can be found on the `cftime documentation <https://unidata.github.io/cftime/api.html#cftime.num2date>`_.
 
 .. _eWaterCycle plugin:
 

--- a/src/ewatercycle/models.py
+++ b/src/ewatercycle/models.py
@@ -20,13 +20,24 @@ registered in the :py:data:`ewatercycle.models`
 `entry point group <https://packaging.python.org/en/latest/specifications/entry-points/>`_.
 """
 
-from importlib.metadata import entry_points
+from importlib.metadata import entry_points, packages_distributions
 from typing import Type
 
 from ewatercycle import shared
 from ewatercycle.base.model import eWaterCycleModel
 
 _model_entrypoints = entry_points(group="ewatercycle.models")  # /NOSONAR
+
+
+def get_package_name(module_name: str) -> str:
+    """Get the (pip) package name from a module name.
+
+    Note: falls back to [unknown] if the lookup fails.
+    """
+    if module_name in packages_distributions():
+        return packages_distributions()[module_name][0]
+    return "[unknown]"
+
 
 # Expose as "from ewatercycle.models import Model" for backward compatibility
 for _model in _model_entrypoints:
@@ -39,7 +50,7 @@ for _model in _model_entrypoints:
             "You can report the issue on the model's github repository, "
             "or on https://github.com/eWaterCycle/ewatercycle/issues\n"
             "In the meantime, you can try uninstalling the plugin with:\n"
-            f"    pip uninstall {_model.value.split('.')[0]}"
+            f"    pip uninstall {get_package_name(_model.value.split('.')[0])}"
         )
         raise ImportError(msg) from e
 

--- a/src/ewatercycle/models.py
+++ b/src/ewatercycle/models.py
@@ -30,7 +30,18 @@ _model_entrypoints = entry_points(group="ewatercycle.models")  # /NOSONAR
 
 # Expose as "from ewatercycle.models import Model" for backward compatibility
 for _model in _model_entrypoints:
-    globals()[_model.name] = _model.load()
+    try:
+        globals()[_model.name] = _model.load()
+    except Exception as e:
+        msg = (
+            "An error was raised when trying to load the plugin of model "
+            f"'{_model.name}'.\n"
+            "You can report the issue on the model's github repository, "
+            "or on https://github.com/eWaterCycle/ewatercycle/issues\n"
+            "In the meantime, you can try uninstalling the plugin with:\n"
+            f"    pip uninstall {_model.value.split('.')[0]}"
+        )
+        raise ImportError(msg) from e
 
 
 class ModelSources(shared.Sources):


### PR DESCRIPTION
The user will now be presented with a more clear error when a plugin is broken. I went for @Peter9192's solution from #391.

closes #391