### PR TITLE
Fix merge_esmvaltool_datasets function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Formatted as described on [https://keepachangelog.com](https://keepachangelog.co
 - If a model plugin raises an exception during the loading of the model entry points, a more clear exception is raised which guides the users on how to solve the error ([#404](https://github.com/eWaterCycle/ewatercycle/pull/404)).
 - Updated the model documentation to link to the eWaterCycleModel API docs, and to make it a bit more clear that it is build on top of BMI ([#403](https://github.com/eWaterCycle/ewatercycle/pull/403)).
 
+### Fixed
+- Fixed an issue related to the `.to_xarray()` method of the generic forcing classes. This method should now be more robust ([#410](https://github.com/eWaterCycle/ewatercycle/pull/410)).
+
 ## [2.1.0] (2024-03-25)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Formatted as described on [https://keepachangelog.com](https://keepachangelog.co
 ### Changed
 - If a model plugin raises an exception during the loading of the model entry points, a more clear exception is raised which guides the users on how to solve the error ([#404](https://github.com/eWaterCycle/ewatercycle/pull/404)).
 - Updated the model documentation to link to the eWaterCycleModel API docs, and to make it a bit more clear that it is build on top of BMI ([#403](https://github.com/eWaterCycle/ewatercycle/pull/403)).
+- Dask has been explicitly added to the ewatercycle package dependencies. The package already depended on it through ESMValTool ([#410](https://github.com/eWaterCycle/ewatercycle/pull/410)).
 
 ### Fixed
 - Fixed an issue related to the `.to_xarray()` method of the generic forcing classes. This method should now be more robust ([#410](https://github.com/eWaterCycle/ewatercycle/pull/410)).

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ have a look at the [contribution guidelines](CONTRIBUTING.md).
 
 ## License
 
-Copyright (c) 2018, Netherlands eScience Center & Delft University of
+Copyright (c) 2018 - 2024, Netherlands eScience Center & Delft University of
 Technology
 
 Apache Software License 2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ install_requires =
     ruamel.yaml
     scipy
     xarray
+    dask
 python_requires = >=3.10
 package_dir =
     = src

--- a/src/ewatercycle/_forcings/makkink.py
+++ b/src/ewatercycle/_forcings/makkink.py
@@ -14,8 +14,14 @@ from ewatercycle.util import merge_esvmaltool_datasets
 
 def derive_e_pot(recipe_output: dict) -> tuple[str, ...]:
     """Derive the Makkink PET from the ESMValTool recipe output."""
-    ds_tas = xr.open_dataset(Path(recipe_output["directory"]) / recipe_output["tas"])
-    ds_rsds = xr.open_dataset(Path(recipe_output["directory"]) / recipe_output["rsds"])
+    ds_tas = xr.open_dataset(
+        Path(recipe_output["directory"]) / recipe_output["tas"],
+        chunks="auto",
+    )
+    ds_rsds = xr.open_dataset(
+        Path(recipe_output["directory"]) / recipe_output["rsds"],
+        chunks="auto",
+    )
     # We need to make sure the coordinates line up. Floating point errors from
     #  ESMValTool mess with this:
     ds = merge_esvmaltool_datasets([ds_tas, ds_rsds])

--- a/src/ewatercycle/base/forcing.py
+++ b/src/ewatercycle/base/forcing.py
@@ -267,7 +267,7 @@ class DefaultForcing(BaseModel):
             raise ValueError(msg)
         fpaths = [self.directory / filename for _, filename in self.filenames.items()]
 
-        datasets = [xr.open_dataset(fpath) for fpath in fpaths]
+        datasets = [xr.open_dataset(fpath, chunks="auto") for fpath in fpaths]
         return merge_esvmaltool_datasets(datasets)
 
     def variables(self) -> tuple[str, ...]:

--- a/src/ewatercycle/util.py
+++ b/src/ewatercycle/util.py
@@ -152,7 +152,7 @@ def merge_esvmaltool_datasets(datasets: list[xr.Dataset]) -> xr.Dataset:
         [1] Randall Monroe, 2019. xkcd: Coordinate Precision. https://xkcd.com/2170/
     """
     TOLERANCE = 1e-7
-    datasets = copy(datasets)
+    datasets = [ds.copy(deep=True) for ds in datasets]
 
     # First check that the coordinates all line up before merging.
     for coord in ["lat", "lon"]:
@@ -195,8 +195,9 @@ def merge_esvmaltool_datasets(datasets: list[xr.Dataset]) -> xr.Dataset:
         #   Instead, we move it to the variable's attributes.
         if "height" in datasets[i].variables:
             data_vars = list(datasets[i].data_vars)
-            if "time_bnds" in data_vars:
-                data_vars.remove("time_bnds")
+            for bnd in ("lat_bnds", "lon_bnds", "time_bnds"):
+                if bnd in data_vars:
+                    data_vars.remove("time_bnds")
             var = data_vars[0]
             datasets[i][var].attrs.update(
                 {

--- a/src/ewatercycle/util.py
+++ b/src/ewatercycle/util.py
@@ -197,8 +197,16 @@ def merge_esvmaltool_datasets(datasets: list[xr.Dataset]) -> xr.Dataset:
             data_vars = list(datasets[i].data_vars)
             for bnd in ("lat_bnds", "lon_bnds", "time_bnds"):
                 if bnd in data_vars:
-                    data_vars.remove("time_bnds")
-            var = data_vars[0]
+                    data_vars.remove(bnd)
+            if len(data_vars) == 1:
+                var = data_vars[0]
+            else:
+                msg = (
+                    "More than one variable found in dataset. \n"
+                    "This routine can only handle a single data variable per dataset\n"
+                )
+                raise ValueError(msg)
+
             datasets[i][var].attrs.update(
                 {
                     "height": float(datasets[i]["height"]),


### PR DESCRIPTION
The merge_esmvaltool_datasets function underlying the generic forcing's `.to_xarray()` method was not very robust. This lead to issues in the CI and #407 .

This PR addresses those problems.