### PR TITLE
Change units caravan forcing

### DIFF
--- a/src/ewatercycle/_forcings/caravan.py
+++ b/src/ewatercycle/_forcings/caravan.py
@@ -209,7 +209,7 @@ class CaravanForcing(DefaultForcing):
 
         for temp in ["tas", "tasmin", "tasmax"]:
             ds_basin_time[temp].attrs.update({"height": "2m"})
-            #convert units to Kelvin for compatiabillity with NetCDF-CF conventions
+            #convert units to Kelvin for compatibility with CMOR MIP table units
             if (ds_basin[temp].attrs["unit"]) == "°C":
                 ds_basin[temp].values = ds_basin[temp].values + 273.15
                 ds_basin[temp].attrs["unit"] = "°K"

--- a/src/ewatercycle/_forcings/caravan.py
+++ b/src/ewatercycle/_forcings/caravan.py
@@ -210,11 +210,15 @@ class CaravanForcing(DefaultForcing):
         for temp in ["tas", "tasmin", "tasmax"]:
             ds_basin_time[temp].attrs.update({"height": "2m"})
             #convert units to Kelvin for compatiabillity with NetCDF-CF conventions
-            ds_basin_time[temp].pint.to(a=temp, u = "K")
+            if (ds_basin[temp].attrs["unit"]) == "°C":
+                ds_basin[temp].values = ds_basin[temp].values + 273.15
+                ds_basin[temp].attrs["unit"] = "°K"
         
         for var in ["evspsblpot", "pr"]:
             #convert units to kg m-2 s-1 for compatiabillity with NetCDF-CF conventions
-            ds_basin_time[var].pint.to(a=var, u = "kg m-2 s-1")
+            if (ds_basin[var].attrs["unit"]) == "mm":
+                ds_basin[var].values = ds_basin[temp].values / (1000 * 86400) #NOTE THAT THIS CONVERSION ASSUMES DAILY DATA
+                ds_basin[var].attrs["unit"] = "kg m-2 s-1"
 
         start_time_name = start_time[:10]
         end_time_name = end_time[:10]

--- a/src/ewatercycle/_forcings/caravan.py
+++ b/src/ewatercycle/_forcings/caravan.py
@@ -207,18 +207,18 @@ class CaravanForcing(DefaultForcing):
         ds_basin_time = ds_basin_time.rename(RENAME_ERA5)
         variables = tuple([RENAME_ERA5[var] for var in variable_names])
 
+        # convert units to Kelvin for compatibility with CMOR MIP table units
         for temp in ["tas", "tasmin", "tasmax"]:
             ds_basin_time[temp].attrs.update({"height": "2m"})
-            #convert units to Kelvin for compatibility with CMOR MIP table units
-            if (ds_basin[temp].attrs["unit"]) == "°C":
-                ds_basin[temp].values = ds_basin[temp].values + 273.15
-                ds_basin[temp].attrs["unit"] = "K"
-        
+            if (ds_basin_time[temp].attrs["unit"]) == "°C":
+                ds_basin_time[temp].values = ds_basin_time[temp].values + 273.15
+                ds_basin_time[temp].attrs["unit"] = "K"
+
         for var in ["evspsblpot", "pr"]:
-            #convert units to kg m-2 s-1 for compatiabillity with NetCDF-CF conventions
-            if (ds_basin[var].attrs["unit"]) == "mm":
-                ds_basin[var].values = ds_basin[temp].values / (86400)  # mm/day --> kg m-2 s-1
-                ds_basin[var].attrs["unit"] = "kg m-2 s-1"
+            if (ds_basin_time[var].attrs["unit"]) == "mm":
+                # mm/day --> kg m-2 s-1
+                ds_basin_time[var].values = ds_basin_time[var].values / (86400)
+                ds_basin_time[var].attrs["unit"] = "kg m-2 s-1"
 
         start_time_name = start_time[:10]
         end_time_name = end_time[:10]

--- a/src/ewatercycle/_forcings/caravan.py
+++ b/src/ewatercycle/_forcings/caravan.py
@@ -217,7 +217,7 @@ class CaravanForcing(DefaultForcing):
         for var in ["evspsblpot", "pr"]:
             #convert units to kg m-2 s-1 for compatiabillity with NetCDF-CF conventions
             if (ds_basin[var].attrs["unit"]) == "mm":
-                ds_basin[var].values = ds_basin[temp].values / (86400) #NOTE THAT THIS CONVERSION ASSUMES DAILY DATA
+                ds_basin[var].values = ds_basin[temp].values / (86400)  # mm/day --> kg m-2 s-1
                 ds_basin[var].attrs["unit"] = "kg m-2 s-1"
 
         start_time_name = start_time[:10]

--- a/src/ewatercycle/_forcings/caravan.py
+++ b/src/ewatercycle/_forcings/caravan.py
@@ -212,7 +212,7 @@ class CaravanForcing(DefaultForcing):
             #convert units to Kelvin for compatibility with CMOR MIP table units
             if (ds_basin[temp].attrs["unit"]) == "°C":
                 ds_basin[temp].values = ds_basin[temp].values + 273.15
-                ds_basin[temp].attrs["unit"] = "°K"
+                ds_basin[temp].attrs["unit"] = "K"
         
         for var in ["evspsblpot", "pr"]:
             #convert units to kg m-2 s-1 for compatiabillity with NetCDF-CF conventions

--- a/src/ewatercycle/_forcings/caravan.py
+++ b/src/ewatercycle/_forcings/caravan.py
@@ -209,6 +209,12 @@ class CaravanForcing(DefaultForcing):
 
         for temp in ["tas", "tasmin", "tasmax"]:
             ds_basin_time[temp].attrs.update({"height": "2m"})
+            #convert units to Kelvin for compatiabillity with NetCDF-CF conventions
+            ds_basin_time[temp].pint.to(a=temp, u = "K")
+        
+        for var in ["evspsblpot", "pr"]:
+            #convert units to kg m-2 s-1 for compatiabillity with NetCDF-CF conventions
+            ds_basin_time[var].pint.to(a=var, u = "kg m-2 s-1")
 
         start_time_name = start_time[:10]
         end_time_name = end_time[:10]

--- a/src/ewatercycle/_forcings/caravan.py
+++ b/src/ewatercycle/_forcings/caravan.py
@@ -217,7 +217,7 @@ class CaravanForcing(DefaultForcing):
         for var in ["evspsblpot", "pr"]:
             #convert units to kg m-2 s-1 for compatiabillity with NetCDF-CF conventions
             if (ds_basin[var].attrs["unit"]) == "mm":
-                ds_basin[var].values = ds_basin[temp].values / (1000 * 86400) #NOTE THAT THIS CONVERSION ASSUMES DAILY DATA
+                ds_basin[var].values = ds_basin[temp].values / (86400) #NOTE THAT THIS CONVERSION ASSUMES DAILY DATA
                 ds_basin[var].attrs["unit"] = "kg m-2 s-1"
 
         start_time_name = start_time[:10]

--- a/tests/src/base/test_forcing.py
+++ b/tests/src/base/test_forcing.py
@@ -333,6 +333,10 @@ def test_retrieve_caravan_forcing(tmp_path: Path, mock_retrieve: mock.MagicMock)
     assert content == expected
     mock_retrieve.assert_called_once_with(basin_id.split("_")[0])
 
+    assert caravan_forcing.to_xarray()["evspsblpot"].attrs["unit"] == "kg m-2 s-1"
+    assert caravan_forcing.to_xarray()["pr"].attrs["unit"] == "kg m-2 s-1"
+    assert caravan_forcing.to_xarray()["tas"].attrs["unit"] == "K"
+
 
 def test_retrieve_caravan_forcing_empty_vars(
     tmp_path: Path, mock_retrieve: mock.MagicMock


### PR DESCRIPTION
I have added a few lines to change the units of the caravan forcings to be in line with the NETCDF CF conventions and compatible with the output of the Makking and Generic Lumped forcings.