### PR TITLE
Copy over the required shapefile files upon saving forcing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Formatted as described on [https://keepachangelog.com](https://keepachangelog.co
 
 ## [Unreleased]
 
+## Fixed
+
+- all required shapefile files (`.shp`, `.shx`, `.dbf`, `.prj`) are now copied to the new directory when saving a forcing object ([#457](https://github.com/eWaterCycle/ewatercycle/pull/457)).
+
 ### [2.3.0] (2024-08-29)
 
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Formatted as described on [https://keepachangelog.com](https://keepachangelog.co
 
 ## Fixed
 
-- all required shapefile files (`.shp`, `.shx`, `.dbf`, `.prj`) are now copied to the new directory when saving a forcing object ([#457](https://github.com/eWaterCycle/ewatercycle/pull/457)).
+- all required shapefile files (`.shp`, `.shx`, `.dbf`, `.prj`) are now copied to the new directory when saving a forcing object ([#430](https://github.com/eWaterCycle/ewatercycle/issues/430)).
 
 ### [2.3.0] (2024-08-29)
 

--- a/src/ewatercycle/base/forcing.py
+++ b/src/ewatercycle/base/forcing.py
@@ -225,6 +225,13 @@ class DefaultForcing(BaseModel):
                 new_shp_path = Path(
                     shutil.copy(clone.shape, clone.directory / clone.shape.name)
                 )
+                if not clone.shape.with_suffix(".prj").exists():
+                    msg = (
+                        "Your shape file is missing the .prj projection file.\n"
+                        "This file is required, as we cannot guess what projection your"
+                        "shapefile is in."
+                    )
+                    raise FileNotFoundError(msg)
                 # Also copy other required files:
                 for ext in [".dbf", ".shx", ".prj"]:
                     shutil.copy(

--- a/src/ewatercycle/base/forcing.py
+++ b/src/ewatercycle/base/forcing.py
@@ -222,9 +222,16 @@ class DefaultForcing(BaseModel):
         # Copy shapefile so statistics like area can be derived
         if clone.shape is not None:
             if not clone.shape.is_relative_to(clone.directory):
-                clone.shape = Path(
+                new_shp_path = Path(
                     shutil.copy(clone.shape, clone.directory / clone.shape.name)
                 )
+                # Also copy other required files:
+                for ext in [".dbf", ".shx", ".prj"]:
+                    shutil.copy(
+                        clone.shape.with_suffix(ext),
+                        clone.directory / clone.shape.with_suffix(ext).name,
+                    )
+                clone.shape = new_shp_path
             clone.shape = clone.shape.relative_to(clone.directory)
 
         fdict = clone.model_dump(exclude={"directory"}, exclude_none=True, mode="json")

--- a/tests/src/base/test_forcing.py
+++ b/tests/src/base/test_forcing.py
@@ -59,6 +59,10 @@ filenames:
 
         assert content == expected
 
+        # make sure all mandatory (shape)files exist
+        for ext in [".dbf", ".prj", ".shp", ".shx"]:
+            assert (forcing.directory / forcing.shape.with_suffix(ext)).exists()
+
 
 class TestGenericDistributedForcingWithInternalShape:
     def test_save(self, tmp_path: Path, sample_shape: str):


### PR DESCRIPTION
Fixes #430 

With this change only [mandatory shapefile files](https://en.wikipedia.org/wiki/Shapefile#Mandatory_files) (.shp, .shx, .dbf) are copied, as well as the projection file (.prj). Other files are not copied (too many possibilities and formats to deal with).

ToDo

- [x] Update changelog
- [x] Test some plugins to ensure nothing breaks

In most plugins we will have to update the tests (as the format of the YAML forcing object has changed slightly). No other tests seem to break


