### PR TITLE
Allow starting remotebmi containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Formatted as described on [https://keepachangelog.com](https://keepachangelog.co
 
 ## Added
 
+- support for [Remote BMI](https://github.com/eWaterCycle/remotebmi), an OpenAPI based alternative for grpc4bmi ([#467](https://github.com/eWaterCycle/ewatercycle/pull/467)).
 - `.get_shape_area()` utility method to the ewatercycle Forcing objects. This returns the area of the shapefile in square meters, useful for converting the results of lumped models (e.g., from mm/day to m3/s) ([#464](https://github.com/eWaterCycle/ewatercycle/issues/464)).
 - `.plot_shape()` utility method to the ewatercycle Forcing objects. This allows plotting the shapefile in a single-line of code, or adds the shapefile to an existing plot ([#464](https://github.com/eWaterCycle/ewatercycle/issues/464)).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     # otherwise pip installation fails on esmpy
     "Fiona",
     "grpc4bmi>=0.4.0",
+    "remotebmi",
     "hydrostats",
     "matplotlib>=3.5.0",
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,6 +205,8 @@ ignore = [
     "E501",
     # Allow prints
     "T201",
+    # Allow shadowing builtins
+    "A004",
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/src/ewatercycle/base/model.py
+++ b/src/ewatercycle/base/model.py
@@ -8,7 +8,7 @@ from collections.abc import ItemsView, Iterable
 from contextlib import suppress
 from datetime import timezone
 from pathlib import Path
-from typing import Annotated, Any, cast
+from typing import Annotated, Any, Literal, cast
 
 import bmipy
 import numpy as np
@@ -439,6 +439,7 @@ class ContainerizedModel(eWaterCycleModel):
     """
 
     bmi_image: Annotated[ContainerImage, BeforeValidator(_parse_containerimage)]
+    protocol: Literal["grpc", "openapi"] = "grpc"
 
     # Create as empty list to allow models to append before bmi is made:
     _additional_input_dirs: list[str] = PrivateAttr([])
@@ -459,6 +460,7 @@ class ContainerizedModel(eWaterCycleModel):
 
         return start_container(
             image=self.bmi_image,
+            protocol=self.protocol,
             work_dir=self._cfg_dir,
             input_dirs=self._additional_input_dirs,
             timeout=300,

--- a/src/ewatercycle/container.py
+++ b/src/ewatercycle/container.py
@@ -137,7 +137,7 @@ def start_container(
     delay=0,
     # TODO replace Any type with Bmi + BmiFromOrigin
     wrappers: Sequence[type[Any]] = (MemoizedBmi, OptionalDestBmi),
-    protocol: Literal["grpc", "openapi"] = "grpc"
+    protocol: Literal["grpc", "openapi"] = "grpc",
 ) -> OptionalDestBmi:
     """Start container with model inside.
 
@@ -187,7 +187,13 @@ def start_container(
 
     if engine == "docker":
         bmi = start_docker_container(
-            work_dir, image, input_dirs, image_port, timeout, delay, protocol,
+            work_dir,
+            image,
+            input_dirs,
+            image_port,
+            timeout,
+            delay,
+            protocol,
         )
     elif engine == "apptainer":
         bmi = start_apptainer_container(
@@ -257,7 +263,6 @@ def start_apptainer_container(
             )
         msg = f"Invalid protocol '{protocol}'!"
         raise ValueError(msg)
-
 
     except FutureTimeoutError as exc:
         msg = (

--- a/tests/src/base/test_model.py
+++ b/tests/src/base/test_model.py
@@ -319,6 +319,23 @@ class TestContainerizedModel:
         )
 
     @patch("ewatercycle.base.model.start_container")
+    def test_remotebmi_setup(self, mocked_start_container, tmp_path: Path):
+        model = ContainerizedModel(
+            bmi_image="ewatercycle/ewatercycle_dummy:latest",
+            protocol="openapi",
+        )
+
+        model.setup(cfg_dir=str(tmp_path))
+
+        mocked_start_container.assert_called_once_with(
+            image="ewatercycle/ewatercycle_dummy:latest",
+            protocol="openapi",
+            work_dir=tmp_path,
+            input_dirs=[],
+            timeout=300,
+        )
+
+    @patch("ewatercycle.base.model.start_container")
     def test_setup_with_additional_input_dirs(
         self, mocked_start_container, tmp_path: Path
     ):

--- a/tests/src/base/test_model.py
+++ b/tests/src/base/test_model.py
@@ -312,6 +312,7 @@ class TestContainerizedModel:
 
         mocked_start_container.assert_called_once_with(
             image="ewatercycle/ewatercycle_dummy:latest",
+            protocol="grpc",
             work_dir=tmp_path,
             input_dirs=[],
             timeout=300,
@@ -345,6 +346,7 @@ class TestContainerizedModel:
 
         mocked_start_container.assert_called_once_with(
             image="ewatercycle/ewatercycle_dummy:latest",
+            protocol="grpc",
             work_dir=tmp_path,
             input_dirs=[
                 str(parameter_set_dir),


### PR DESCRIPTION
This PR adds support for remotebmi.

The arguments between grpc4bmi and remotebmi differ subtlety, so I had to add an extra "protocol" property to the eWaterCycle Model class.

eg:

```py
RemoteBMIModel(eWaterCycleModel):
    bmi_image: ContainerImage("ghcr.io/ewatercycle/ewatercycle-walrus:latest")
    protocol= "openapi"
...
```