### PR TITLE
478 caravan forcing downloads and unzips shapefiles for all caravan with each basin leads to errors fixes #478

### DIFF
--- a/src/ewatercycle/_forcings/caravan.py
+++ b/src/ewatercycle/_forcings/caravan.py
@@ -188,7 +188,6 @@ class CaravanForcing(DefaultForcing):
         ds_basin = ds.sel(basin_id=basin_id.encode())
         ds_basin_time = crop_ds(ds_basin, start_time, end_time)
 
-        
         if shape_in is None:
             shape = get_shapefiles(Path(directory), basin_id)
         elif Path(shape_in).name == "combined.shp":

--- a/src/ewatercycle/_forcings/caravan.py
+++ b/src/ewatercycle/_forcings/caravan.py
@@ -164,7 +164,8 @@ class CaravanForcing(DefaultForcing):
             directory: Directory in which forcing should be written.
             variables: Variables which are needed for model,
                 if not specified will default to all.
-            shape_in: (Optional) Path to a shape file of the basin, or the combined.shp file of all basins.
+            shape_in: (Optional) Path to a shape file of the basin, or the combined.shp 
+                file of all basins.
                 If none is specified, will be downloaded automatically.
             kwargs: Additional keyword arguments.
                 basin_id: The ID of the desired basin. Data sets can be explored using

--- a/src/ewatercycle/_forcings/caravan.py
+++ b/src/ewatercycle/_forcings/caravan.py
@@ -164,7 +164,7 @@ class CaravanForcing(DefaultForcing):
             directory: Directory in which forcing should be written.
             variables: Variables which are needed for model,
                 if not specified will default to all.
-            shape: (Optional) Path to a shape file.
+            shape_in: (Optional) Path to a shape file of the basin, or the combined.shp file of all basins.
                 If none is specified, will be downloaded automatically.
             kwargs: Additional keyword arguments.
                 basin_id: The ID of the desired basin. Data sets can be explored using
@@ -193,7 +193,7 @@ class CaravanForcing(DefaultForcing):
         elif Path(shape_in).name == "combined.shp":
             shape = Path(directory) / f"{basin_id}.shp"
             extract_basin_shapefile(basin_id, Path(shape_in), shape)
-        elif not (Path(shape).name == f"{basin_id}.shp"):
+        elif Path(shape).name != f"{basin_id}.shp":
             msg = (
                 "shape must either point to a shapefile of the basin ID"
                 "Or to the combined.shp file that contains all basins."
@@ -310,9 +310,6 @@ def extract_basin_shapefile(
                 # kind of clunky but it works: select filtered polygon
                 if i == basin_index:
                     geom = feat.geometry
-                    # if geom.type != "Polygon":
-                    #     msg = "Only polygons are supported"
-                    #     raise ValueError(msg)
 
                     # Add the signed area of the polygon and a timestamp
                     # to the feature properties map.

--- a/src/ewatercycle/_forcings/caravan.py
+++ b/src/ewatercycle/_forcings/caravan.py
@@ -188,8 +188,18 @@ class CaravanForcing(DefaultForcing):
         ds_basin = ds.sel(basin_id=basin_id.encode())
         ds_basin_time = crop_ds(ds_basin, start_time, end_time)
 
+        
         if shape is None:
             shape = get_shapefiles(Path(directory), basin_id)
+        elif Path(shape).name == "combined.shp":
+            shape_path_out = Path(directory) / f"{basin_id}.shp"
+            extract_basin_shapefile(basin_id, Path(shape), shape_path_out)
+        elif not (Path(shape).name == f"{basin_id}.shp"):
+            msg = (
+                "shape must either point to a shapefile of the basin ID"
+                "Or to the combined.shp file that contains all basins."
+            )
+            raise ValueError(msg)
 
         if len(variables) == 0:
             variables = ds_basin_time.data_vars.keys()  # type: ignore[assignment]

--- a/src/ewatercycle/_forcings/caravan.py
+++ b/src/ewatercycle/_forcings/caravan.py
@@ -151,7 +151,7 @@ class CaravanForcing(DefaultForcing):
         end_time: str,
         directory: str,
         variables: tuple[str, ...] = (),
-        shape: str | Path | None = None,
+        shape_in: str | Path | None = None,
         **kwargs,
     ) -> "CaravanForcing":
         """Retrieve caravan for a model.
@@ -189,17 +189,19 @@ class CaravanForcing(DefaultForcing):
         ds_basin_time = crop_ds(ds_basin, start_time, end_time)
 
         
-        if shape is None:
+        if shape_in is None:
             shape = get_shapefiles(Path(directory), basin_id)
-        elif Path(shape).name == "combined.shp":
-            shape_path_out = Path(directory) / f"{basin_id}.shp"
-            extract_basin_shapefile(basin_id, Path(shape), shape_path_out)
+        elif Path(shape_in).name == "combined.shp":
+            shape = Path(directory) / f"{basin_id}.shp"
+            extract_basin_shapefile(basin_id, Path(shape_in), shape)
         elif not (Path(shape).name == f"{basin_id}.shp"):
             msg = (
                 "shape must either point to a shapefile of the basin ID"
                 "Or to the combined.shp file that contains all basins."
             )
             raise ValueError(msg)
+        else:
+            shape = shape_in
 
         if len(variables) == 0:
             variables = ds_basin_time.data_vars.keys()  # type: ignore[assignment]
@@ -309,9 +311,9 @@ def extract_basin_shapefile(
                 # kind of clunky but it works: select filtered polygon
                 if i == basin_index:
                     geom = feat.geometry
-                    if geom.type != "Polygon":
-                        msg = "Only polygons are supported"
-                        raise ValueError(msg)
+                    # if geom.type != "Polygon":
+                    #     msg = "Only polygons are supported"
+                    #     raise ValueError(msg)
 
                     # Add the signed area of the polygon and a timestamp
                     # to the feature properties map.


### PR DESCRIPTION
allowed the option in shape to point to combined.shp file that is already downloaded. Removed the check on polygons, which threw an error that was not correct stopping workflows