### PR TITLE
Make Makkink forcing compatible with any climate model data

### DIFF
--- a/src/ewatercycle/_forcings/makkink.py
+++ b/src/ewatercycle/_forcings/makkink.py
@@ -20,12 +20,14 @@ def derive_e_pot(recipe_output: dict) -> tuple[str, ...]:
         decode_cf=False,
     )
     ds_tas = xr.decode_cf(ds_tas)  # decoding after loading makes Dask happy.
+    ds_tas["time_bnds"].load()  # Need to be in memory for merging datasets.
     ds_rsds = xr.open_dataset(
         Path(recipe_output["directory"]) / recipe_output["rsds"],
         chunks="auto",
         decode_cf=False,
     )
     ds_rsds = xr.decode_cf(ds_rsds)
+    ds_rsds["time_bnds"].load()
     # We need to make sure the coordinates line up. Floating point errors from
     #  ESMValTool mess with this:
     ds = merge_esvmaltool_datasets([ds_tas, ds_rsds])

--- a/src/ewatercycle/_forcings/makkink.py
+++ b/src/ewatercycle/_forcings/makkink.py
@@ -17,11 +17,15 @@ def derive_e_pot(recipe_output: dict) -> tuple[str, ...]:
     ds_tas = xr.open_dataset(
         Path(recipe_output["directory"]) / recipe_output["tas"],
         chunks="auto",
+        decode_cf=False,
     )
+    ds_tas = xr.decode_cf(ds_tas)  # decoding after loading makes Dask happy.
     ds_rsds = xr.open_dataset(
         Path(recipe_output["directory"]) / recipe_output["rsds"],
         chunks="auto",
+        decode_cf=False,
     )
+    ds_rsds = xr.decode_cf(ds_rsds)
     # We need to make sure the coordinates line up. Floating point errors from
     #  ESMValTool mess with this:
     ds = merge_esvmaltool_datasets([ds_tas, ds_rsds])

--- a/src/ewatercycle/util.py
+++ b/src/ewatercycle/util.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import fiona
 import numpy as np
+import pandas as pd
 import xarray as xr
 from dateutil.parser import parse
 from shapely import geometry
@@ -226,7 +227,7 @@ def merge_esvmaltool_datasets(datasets: list[xr.Dataset]) -> xr.Dataset:
         if "time_bnds" in datasets[i] and xr.infer_freq(datasets[i]["time"]) == "D":
             datasets[i]["time"] = datasets[i]["time_bnds"].isel(
                 bnds=0
-            ) + np.timedelta64(12, "h")
+            ) + pd.Timedelta("12H")
             datasets[i] = datasets[i].drop_vars("time_bnds")
 
         # A "height" coordinate can be present, which will result in conflicts.


### PR DESCRIPTION
Fixes #486 

```py
import ewatercycle
from ewatercycle.testing.fixings import rhine_shape

cmip_dataset = {
    "dataset": "GFDL-ESM2G",
    "project": "CMIP5",
    "grid": "gr",
    "exp": "historical",
    "ensemble": "r1i1p1",
}

cmip_forcing = ewatercycle.forcing.sources["LumpedMakkinkForcing"].generate(
    dataset=cmip_dataset,
    start_time=experiment_start_date,
    end_time=experiment_end_date,
    shape=rhine_shape(),
)
```
fails on `main`. ~~should pass with this branch.~~ Tested it now I'm at the office. Works now.